### PR TITLE
Ux flow

### DIFF
--- a/web/site/app.vue
+++ b/web/site/app.vue
@@ -18,7 +18,6 @@ useHead({
   <div
     class="relative flex min-h-screen flex-col bg-bcGovColor-gray1 dark:bg-bcGovGray-900"
   >
-    <!-- <NuxtLoadingIndicator /> -->
     <SbcLoadingSpinner v-if="loadStore.pageLoading" overlay />
     <SbcHeaderMain />
     <NuxtLayout>

--- a/web/site/components/Sbc/PageSection/h1.vue
+++ b/web/site/components/Sbc/PageSection/h1.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{
+  heading?: string
+}>()
+</script>
+<template>
+  <h1 class="text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
+    {{ heading || '' }}
+    <slot />
+  </h1>
+</template>

--- a/web/site/components/content/BusinessEmail.vue
+++ b/web/site/components/content/BusinessEmail.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
 const busStore = useBusinessStore()
+const accountStore = useAccountStore()
+
+const displayEmail = computed(() => {
+  const mailingAddress = accountStore.currentAccount?.mailingAddress
+  if (mailingAddress && mailingAddress.length > 0 && 'email' in mailingAddress[0]) {
+    return mailingAddress[0].email
+  } else {
+    return busStore.currentBusiness?.email ?? 'No email found'
+  }
+})
 </script>
 <template>
-  <span class="not-prose font-semibold">{{ busStore.currentBusiness.email ?? 'No email found' }}</span>
+  <span class="not-prose font-semibold">{{ displayEmail }}</span>
 </template>

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -131,6 +131,7 @@ export default {
               req: 'Please enter a Phone Number',
               invalid: 'Please enter a valid phone number'
             },
+            phoneExt: 'Please enter a valid extension',
             email: {
               req: 'Please enter an Email Address',
               invalid: 'Please enter a valid email address'

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -131,6 +131,7 @@ export default {
               req: 'Veuillez entrer un numéro de téléphone',
               invalid: 'Veuillez entrer un numéro de téléphone valide'
             },
+            phoneExt: 'Veuillez entrer une extension valide', // TODO: review
             email: {
               req: "Veuillez entrer une adresse email s'il vous plaît",
               invalid: 'Veuillez entrer une adresse email valide'

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/site/pages/accounts/choose-existing.vue
+++ b/web/site/pages/accounts/choose-existing.vue
@@ -23,7 +23,7 @@ async function handleAccountSelect (id: number) {
   setAccountLoading.value = false
 }
 
-onMounted(async () => {
+async function initPage () {
   try {
     const accounts = await accountStore.getUserAccounts()
     if (accounts?.orgs.length === 0 || accounts === undefined) {
@@ -34,7 +34,12 @@ onMounted(async () => {
   } finally {
     loadStore.pageLoading = false
   }
-})
+}
+
+// init page in setup lifecycle
+if (import.meta.client) {
+  initPage()
+}
 </script>
 <template>
   <ClientOnly>

--- a/web/site/pages/accounts/choose-existing.vue
+++ b/web/site/pages/accounts/choose-existing.vue
@@ -16,11 +16,10 @@ definePageMeta({
   middleware: ['filing-paid', 'filing-in-progress']
 })
 
-async function handleAccountSelect (id: number) {
+function handleAccountSelect (id: number) {
   setAccountLoading.value = true
   accountStore.selectUserAccount(id)
-  await navigateTo(localePath('/annual-report'))
-  setAccountLoading.value = false
+  return navigateTo(localePath('/annual-report'))
 }
 
 async function initPage () {

--- a/web/site/pages/accounts/choose-existing.vue
+++ b/web/site/pages/accounts/choose-existing.vue
@@ -43,9 +43,10 @@ if (import.meta.client) {
 <template>
   <ClientOnly>
     <div class="mx-auto flex flex-col items-center gap-4 text-left sm:gap-8">
-      <h1 class="self-start text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-        {{ $t('page.existingAccount.h1') }}
-      </h1>
+      <SbcPageSectionH1
+        :heading="$t('page.existingAccount.h1')"
+        class="self-start"
+      />
       <UCard class="w-full max-w-5xl border border-bcGovColor-navDivider bg-[#FFF7E3]">
         <div class="flex items-center gap-2">
           <p class="text-bcGovColor-midGray dark:text-gray-300">

--- a/web/site/pages/accounts/create-new.vue
+++ b/web/site/pages/accounts/create-new.vue
@@ -87,9 +87,10 @@ if (import.meta.client) {
 <template>
   <ClientOnly>
     <div class="mx-auto flex w-full max-w-[1360px] flex-col items-center gap-8 text-left">
-      <h1 class="self-start text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-        {{ $t('page.createAccount.h1') }}
-      </h1>
+      <SbcPageSectionH1
+        class="self-start"
+        :heading="$t('page.createAccount.h1')"
+      />
       <SbcPageSectionCard
         :heading="$t('page.createAccount.h2')"
       >

--- a/web/site/pages/accounts/create-new.vue
+++ b/web/site/pages/accounts/create-new.vue
@@ -43,7 +43,7 @@ async function submitCreateAccountForm (event: FormSubmitEvent<FormSchema>) {
   try {
     formLoading.value = true
     await accountStore.createNewAccount(event.data)
-    await navigateTo(localePath('/annual-report'))
+    return navigateTo(localePath('/annual-report'))
   } catch (e) {
     console.error(e)
   } finally {
@@ -73,15 +73,16 @@ const validate = async (state: any): Promise<FormError[]> => {
 }
 
 // try to prefill account name on page load
-onMounted(async () => {
+if (import.meta.client) {
   try {
-    accountDetails.accountName = await accountStore.findAvailableAccountName(keycloak.kcUser.value.lastName)
+    const name = parseSpecialChars(keycloak.kcUser.value.fullName, '') // parse name if special chars
+    accountDetails.accountName = await accountStore.findAvailableAccountName(name) // find account name using users name
   } catch (error) {
     console.error((error as Error).message)
   } finally {
     loadStore.pageLoading = false
   }
-})
+}
 </script>
 <template>
   <ClientOnly>
@@ -89,21 +90,9 @@ onMounted(async () => {
       <h1 class="self-start text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
         {{ $t('page.createAccount.h1') }}
       </h1>
-      <UCard
-        class="w-full"
-        :ui="{
-          header: {
-            base: '',
-            background: 'bg-bcGovColor-gray2',
-            padding: 'px-4 py-5 sm:px-6',
-          }
-        }"
+      <SbcPageSectionCard
+        :heading="$t('page.createAccount.h2')"
       >
-        <template #header>
-          <h2 class="font-semibold text-bcGovColor-darkGray dark:text-white">
-            {{ $t('page.createAccount.h2') }}
-          </h2>
-        </template>
         <!-- display current users name -->
         <div class="flex flex-col gap-y-4 md:grid md:grid-cols-6">
           <span class="col-span-1 col-start-1 font-semibold text-bcGovColor-darkGray">{{ $t('page.createAccount.form.infoSection.fieldSet') }}</span>
@@ -184,7 +173,7 @@ onMounted(async () => {
             </div>
           </div>
         </UForm>
-      </UCard>
+      </SbcPageSectionCard>
     </div>
   </ClientOnly>
 </template>

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -161,9 +161,7 @@ if (import.meta.client) {
   <ClientOnly>
     <div v-show="!loadStore.pageLoading" class="relative mx-auto flex w-full max-w-[1360px] flex-col gap-4 text-left sm:gap-4 md:flex-row md:gap-6">
       <div class="flex w-full flex-col gap-6">
-        <h1 class="text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-          {{ $t('page.annualReport.h1', { year: busStore.currentBusiness.nextARYear}) }}
-        </h1>
+        <SbcPageSectionH1 :heading="$t('page.annualReport.h1', { year: busStore.currentBusiness.nextARYear})" />
 
         <UAlert
           v-if="errorAlert.title || errorAlert.description"

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -73,6 +73,9 @@ const validate = (state: any): FormError[] => {
 
 // handle submitting filing and directing to pay screen
 async function submitAnnualReport (event: FormSubmitEvent<any>) {
+  arStore.errors = [] // reset errors
+  errorAlert.title = ''
+  errorAlert.description = ''
   try {
     loading.value = true
     // set data based off radio button value
@@ -88,11 +91,9 @@ async function submitAnnualReport (event: FormSubmitEvent<any>) {
       // redirect to pay with the returned token and filing id
       await handlePaymentRedirect(paymentToken, filingId)
     }
-  } catch (e) {
-    // log and display error alert if this fails
-    const msg = (e as Error).message ?? 'Could not complete filing or payment request, please try again.'
-    console.error(msg)
-    errorAlert.description = msg
+  } catch {
+    // display error
+    errorAlert.description = arStore.errors[0].message
   } finally {
     loading.value = false
   }
@@ -127,10 +128,9 @@ watch(
   }
 )
 
+// init page state
 if (import.meta.client) {
-  console.log('setting up ar page')
   try {
-    // loadStore.pageLoading = true
     // load fees for fee widget, might move into earlier setup
     addBarPayFees()
     await busStore.getFullBusinessDetails()
@@ -156,33 +156,6 @@ if (import.meta.client) {
     loadStore.pageLoading = false
   }
 }
-// onMounted(async () => {
-//   try {
-//     // load fees for fee widget, might move into earlier setup
-//     addBarPayFees()
-//     await busStore.getFullBusinessDetails()
-//     // try to prefill form if a filing exists
-//     if (Object.keys(arStore.arFiling).length !== 0) {
-//       // add payment error message if pay status exists and doesnt equal paid
-//       if (arStore.arFiling.filing.header.status && arStore.arFiling.filing.header.status !== 'PAID') {
-//         errorAlert.title = t('page.annualReport.payError.title')
-//         errorAlert.description = t('page.annualReport.payError.description')
-//       }
-
-//       const votedForNoAGM = arStore.arFiling.filing.annualReport.votedForNoAGM
-//       const agmDate = arStore.arFiling.filing.annualReport.annualGeneralMeetingDate
-//       if (votedForNoAGM) {
-//         selectedRadio.value = 'option-3'
-//       } else if (!votedForNoAGM && !agmDate) {
-//         selectedRadio.value = 'option-2'
-//       } else if (agmDate) {
-//         arData.agmDate = agmDate
-//       }
-//     }
-//   } finally {
-//     loadStore.pageLoading = false
-//   }
-// })
 </script>
 <template>
   <ClientOnly>

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -8,7 +8,6 @@ const busStore = useBusinessStore()
 const arStore = useAnnualReportStore()
 const payFeesWidget = usePayFeesWidget()
 const loadStore = useLoadingStore()
-loadStore.pageLoading = true
 
 useHead({
   title: t('page.annualReport.title')
@@ -128,10 +127,10 @@ watch(
   }
 )
 
-// TODO use business details from api call for address and directors
-
-onMounted(async () => {
+if (import.meta.client) {
+  console.log('setting up ar page')
   try {
+    // loadStore.pageLoading = true
     // load fees for fee widget, might move into earlier setup
     addBarPayFees()
     await busStore.getFullBusinessDetails()
@@ -156,7 +155,34 @@ onMounted(async () => {
   } finally {
     loadStore.pageLoading = false
   }
-})
+}
+// onMounted(async () => {
+//   try {
+//     // load fees for fee widget, might move into earlier setup
+//     addBarPayFees()
+//     await busStore.getFullBusinessDetails()
+//     // try to prefill form if a filing exists
+//     if (Object.keys(arStore.arFiling).length !== 0) {
+//       // add payment error message if pay status exists and doesnt equal paid
+//       if (arStore.arFiling.filing.header.status && arStore.arFiling.filing.header.status !== 'PAID') {
+//         errorAlert.title = t('page.annualReport.payError.title')
+//         errorAlert.description = t('page.annualReport.payError.description')
+//       }
+
+//       const votedForNoAGM = arStore.arFiling.filing.annualReport.votedForNoAGM
+//       const agmDate = arStore.arFiling.filing.annualReport.annualGeneralMeetingDate
+//       if (votedForNoAGM) {
+//         selectedRadio.value = 'option-3'
+//       } else if (!votedForNoAGM && !agmDate) {
+//         selectedRadio.value = 'option-2'
+//       } else if (agmDate) {
+//         arData.agmDate = agmDate
+//       }
+//     }
+//   } finally {
+//     loadStore.pageLoading = false
+//   }
+// })
 </script>
 <template>
   <ClientOnly>

--- a/web/site/pages/index.vue
+++ b/web/site/pages/index.vue
@@ -16,7 +16,7 @@ definePageMeta({
   order: 0
 })
 
-onMounted(async () => {
+if (import.meta.client) {
   try {
     // get business task is user is logged in (user was redirected after keycloak login)
     if (keycloak.isAuthenticated()) {
@@ -45,14 +45,17 @@ onMounted(async () => {
   } finally {
     loadStore.pageLoading = false
   }
-})
+}
 </script>
 <template>
   <!-- must use v-show for nuxt content to prerender correctly -->
   <div v-show="!loadStore.pageLoading" class="mx-auto flex max-w-[95vw] flex-col items-center justify-center gap-4 text-center">
     <ClientOnly>
       <!-- show different h1 depending on pay status -->
-      <h1 v-if="busStore.payStatus === 'PAID'" class="flex w-fit items-center justify-center gap-2 text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
+      <SbcPageSectionH1
+        v-if="busStore.payStatus === 'PAID'"
+        class="flex w-fit items-center justify-center gap-2"
+      >
         <span>{{ $t('page.submitted.h1') }}</span>
         <span class="flex items-center justify-center">
           <UIcon
@@ -60,10 +63,9 @@ onMounted(async () => {
             class="size-10 text-outcomes-approved"
           />
         </span>
-      </h1>
-      <h1 v-else class="text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-        {{ $t('page.home.h1') }}
-      </h1>
+      </SbcPageSectionH1>
+      <SbcPageSectionH1 :heading="$t('page.home.h1')" />
+
       <!-- show business details -->
       <UCard class="w-full overflow-x-auto" data-testid="bus-details-card">
         <SbcBusinessInfo

--- a/web/site/pages/missing-id.vue
+++ b/web/site/pages/missing-id.vue
@@ -15,11 +15,7 @@ definePageMeta({
 </script>
 <template>
   <div class="mx-auto flex flex-col items-center justify-center gap-4 text-center">
-    <ClientOnly>
-      <h1 class="text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-        {{ $t('page.missingId.h1') }}
-      </h1>
-    </ClientOnly>
+    <SbcPageSectionH1 :heading="$t('page.missingId.h1')" />
     <SbcNuxtContentCard id="missing-id" />
     <!-- this is only for dev to enter nano ids -->
     <div class="flex gap-2">

--- a/web/site/pages/submitted.vue
+++ b/web/site/pages/submitted.vue
@@ -14,8 +14,7 @@ definePageMeta({
   middleware: ['filing-paid', 'require-account']
 })
 
-// TODO: need to handle if theres no filing id in the route query or if the put request fails
-onMounted(async () => {
+if (import.meta.client) {
   try {
     if (!route.query.filing_id) {
       throw new Error('Missing filing id in url.')
@@ -33,7 +32,7 @@ onMounted(async () => {
   } finally {
     loadStore.pageLoading = false
   }
-})
+}
 </script>
 <template>
   <div v-show="!loadStore.pageLoading" class="mx-auto flex flex-col items-center justify-center gap-4 text-center">

--- a/web/site/pages/submitted.vue
+++ b/web/site/pages/submitted.vue
@@ -14,7 +14,7 @@ definePageMeta({
   middleware: ['filing-paid', 'require-account']
 })
 
-if (import.meta.client) {
+async function initPage () {
   try {
     if (!route.query.filing_id) {
       throw new Error('Missing filing id in url.')
@@ -22,29 +22,30 @@ if (import.meta.client) {
       // check filing status details
       await busStore.updatePaymentStatusForBusiness(route.query.filing_id as string)
       if (busStore.payStatus && busStore.payStatus !== 'PAID') {
-        await navigateTo(localePath('/annual-report'))
+        return navigateTo(localePath('/annual-report'))
       }
+      loadStore.pageLoading = false
     }
   } catch (e) {
     // go back to ar page if no filing id or error in the PUT request
     console.error((e as Error).message)
-    await navigateTo(localePath('/annual-report'))
-  } finally {
-    loadStore.pageLoading = false
+    return navigateTo(localePath('/annual-report'))
   }
+}
+
+if (import.meta.client) {
+  initPage()
 }
 </script>
 <template>
   <div v-show="!loadStore.pageLoading" class="mx-auto flex flex-col items-center justify-center gap-4 text-center">
-    <ClientOnly>
-      <h1 class="flex items-center gap-2 text-3xl font-semibold text-bcGovColor-darkGray dark:text-white">
-        <span>{{ $t('page.submitted.h1') }}</span>
-        <UIcon
-          name="i-mdi-check-circle-outline"
-          class="size-10 shrink-0 text-outcomes-approved"
-        />
-      </h1>
-    </ClientOnly>
+    <SbcPageSectionH1 class="flex items-center gap-2">
+      <span>{{ $t('page.submitted.h1') }}</span>
+      <UIcon
+        name="i-mdi-check-circle-outline"
+        class="size-10 shrink-0 text-outcomes-approved"
+      />
+    </SbcPageSectionH1>
     <SbcNuxtContentCard id="submitted" />
   </div>
 </template>

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -10,6 +10,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
   // store values
   const loading = ref<boolean>(true)
   const arFiling = ref<ArFilingResponse>({} as ArFilingResponse)
+  const errors = ref<Array<{ message: string, statusCode: number }>>([])
 
   async function submitAnnualReportFiling (agmData: ARFiling): Promise<{ paymentToken: number, filingId: number, payStatus: string }> {
     let apiSuffix = `/business/${busStore.businessNano.identifier}/filings`
@@ -44,9 +45,14 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         // console.log(arFiling.value)
       },
       onResponseError ({ response }) {
-        // console error a message from the api or a default message
-        const errorMsg = response._data.message ?? 'Error submitting annual report filing.'
+        let errorMsg = response._data.message ?? 'Could not complete filing or payment request, please try again.'
         console.error(errorMsg)
+        if (response.status !== 400) {
+          errorMsg = 'Could not complete filing or payment request, please try again.'
+        }
+        errors.value.push(
+          { message: errorMsg, statusCode: response.status }
+        )
       }
     })
 
@@ -60,11 +66,13 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
   function $reset () {
     loading.value = true
     arFiling.value = {} as ArFilingResponse
+    errors.value = []
   }
 
   return {
     loading,
     arFiling,
+    errors,
     submitAnnualReportFiling,
     $reset
   }


### PR DESCRIPTION
- parse special character names in account name prefill
- h1 heading component for each page
- display email from account and fall back to business (might change)
- add generic error message to ar page if filing fails
- move all page init statements to setup lifecycle using if import.meta.client
- cleanup page init loading flow for smoother ux