### PR TITLE
overwrite content headers to not create header links

### DIFF
--- a/web/site/components/content/ProseH1.vue
+++ b/web/site/components/content/ProseH1.vue
@@ -1,0 +1,5 @@
+<template>
+  <h1>
+    <slot />
+  </h1>
+</template>

--- a/web/site/components/content/ProseH2.vue
+++ b/web/site/components/content/ProseH2.vue
@@ -1,0 +1,5 @@
+<template>
+  <h2>
+    <slot />
+  </h2>
+</template>

--- a/web/site/components/content/ProseH3.vue
+++ b/web/site/components/content/ProseH3.vue
@@ -1,0 +1,5 @@
+<template>
+  <h3>
+    <slot />
+  </h3>
+</template>

--- a/web/site/components/content/ProseH4.vue
+++ b/web/site/components/content/ProseH4.vue
@@ -1,0 +1,5 @@
+<template>
+  <h4>
+    <slot />
+  </h4>
+</template>

--- a/web/site/components/content/ProseH5.vue
+++ b/web/site/components/content/ProseH5.vue
@@ -1,0 +1,5 @@
+<template>
+  <h5>
+    <slot />
+  </h5>
+</template>

--- a/web/site/components/content/ProseH6.vue
+++ b/web/site/components/content/ProseH6.vue
@@ -1,0 +1,5 @@
+<template>
+  <h6>
+    <slot />
+  </h6>
+</template>

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
Overwrite Prose heading components so they don't create an anchor tag.

Before:
![Screenshot 2024-06-20 at 10 22 11 AM](https://github.com/bcgov/business-ar/assets/73151365/508d3c79-afa6-4362-830a-9094ba981ef1)

After: 
<img width="464" alt="Screenshot 2024-06-20 at 10 22 22 AM" src="https://github.com/bcgov/business-ar/assets/73151365/fed42564-e01d-4a51-9956-7616ab0f9f07">
 