### PR TITLE
Compliance warning link and address review tooltip

### DIFF
--- a/web/site/app.config.ts
+++ b/web/site/app.config.ts
@@ -126,7 +126,7 @@ export default defineAppConfig({
     popover: {
       background: 'bg-gray-700',
       ring: 'ring-1 ring-gray-700',
-      width: 'max-w-xs',
+      width: 'max-w-sm',
       popper: {
         // arrow: true
       },

--- a/web/site/app.config.ts
+++ b/web/site/app.config.ts
@@ -123,6 +123,21 @@ export default defineAppConfig({
         }
       }
     },
+    popover: {
+      background: 'bg-gray-700',
+      ring: 'ring-1 ring-gray-700',
+      width: 'max-w-xs',
+      popper: {
+        // arrow: true
+      },
+      arrow: {
+        base: 'before:w-3 before:h-3',
+        ring: 'before:ring-1 before:ring-gray-700',
+        background: 'before:bg-gray-700',
+        rounded: 'before:rounded-none',
+        placement: "group-data-[popper-placement*='right']:-left-1 group-data-[popper-placement*='left']:-right-1 group-data-[popper-placement*='top']:-bottom-1 group-data-[popper-placement*='bottom']:-top-1"
+      }
+    },
     radio: {
       border: 'border-gray-500'
     },
@@ -218,7 +233,7 @@ export default defineAppConfig({
       color: 'text-white',
       ring: 'ring-1 ring-gray-700',
       rounded: 'rounded',
-      base: '[@media(pointer:coarse)]:hidden h-auto px-2 py-1 text-sm font-normal relative whitespace-normal',
+      base: 'h-auto px-2 py-1 text-sm font-normal relative whitespace-normal',
       arrow: {
         base: 'before:w-3 before:h-3',
         ring: 'before:ring-1 before:ring-gray-700',

--- a/web/site/app.config.ts
+++ b/web/site/app.config.ts
@@ -126,7 +126,7 @@ export default defineAppConfig({
     popover: {
       background: 'bg-gray-700',
       ring: 'ring-1 ring-gray-700',
-      width: 'max-w-sm',
+      width: 'max-w-xs sm:max-w-sm',
       popper: {
         // arrow: true
       },

--- a/web/site/components/Sbc/I18nBold.vue
+++ b/web/site/components/Sbc/I18nBold.vue
@@ -3,17 +3,16 @@ const props = defineProps({
   translationPath: { type: String, required: true }
 })
 
+const attrs = useAttrs()
 const { t } = useI18n()
 
-const text = t(props.translationPath as string, {
-  boldStart: '{b}',
-  boldEnd: '{/b}'
-})
+const translationProps = {
+  ...attrs,
+  boldStart: '<strong>',
+  boldEnd: '</strong>'
+}
 
-const textToDisplay = text.replace(
-  /\{b\}(.*?)\{\/b\}/g,
-  '<strong>$1</strong>'
-)
+const textToDisplay = t(props.translationPath, translationProps)
 </script>
 <template>
   <!-- eslint-disable-next-line -->

--- a/web/site/components/Sbc/Table/Address/index.vue
+++ b/web/site/components/Sbc/Table/Address/index.vue
@@ -3,8 +3,8 @@ const { t } = useI18n()
 
 const props = defineProps<{
   offices: {
-    recordsOffice: Office
-    registeredOffice: Office
+    recordsOffice?: Office
+    registeredOffice?: Office
   } | undefined
 }>()
 
@@ -24,19 +24,22 @@ const columns = [
 ]
 
 const addresses = computed(() => {
-  if (!props.offices) { return [] }
-  return [
-    {
+  const offices = []
+  if (props.offices?.registeredOffice) {
+    offices.push({
       name: t('labels.registeredOffice'),
       mailingAddress: props.offices.registeredOffice.mailingAddress,
       deliveryAddress: props.offices.registeredOffice.deliveryAddress
-    },
-    {
+    })
+  }
+  if (props.offices?.recordsOffice) {
+    offices.push({
       name: t('labels.recordsOffice'),
       mailingAddress: props.offices.recordsOffice.mailingAddress,
       deliveryAddress: props.offices.recordsOffice.deliveryAddress
-    }
-  ]
+    })
+  }
+  return offices
 })
 </script>
 <template>

--- a/web/site/components/Sbc/Tooltip.vue
+++ b/web/site/components/Sbc/Tooltip.vue
@@ -32,7 +32,7 @@ const isTouchScreen = useMediaQuery('(pointer: coarse)')
       </template>
 
       <template #panel>
-        <p class="px-2 py-1 text-sm font-normal text-white">
+        <p class="p-2.5 text-sm font-normal text-white">
           {{ text }}
         </p>
       </template>

--- a/web/site/components/Sbc/Tooltip.vue
+++ b/web/site/components/Sbc/Tooltip.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+defineProps<{
+  text: string
+  id?: string
+}>()
+
+const isTouchScreen = useMediaQuery('(pointer: coarse)')
+</script>
+<template>
+  <div class="inline-flex items-center align-text-top">
+    <UPopover
+      :mode="isTouchScreen ? 'click' : 'hover'"
+    >
+      <template #default="{ open }">
+        <UButton
+          type="button"
+          :padded="false"
+          variant="link"
+          icon="i-mdi-info-outline"
+          class="cursor-default"
+          size="xl"
+          :aria-label="open ? $t('btn.info.hide') : $t('btn.info.show')"
+        />
+        <!-- live region will announce text when button opens popover -->
+        <span role="status" class="sr-only">
+          {{ open ? text : '' }}
+        </span>
+        <!-- text for aria aria-describedby -->
+        <p v-if="id" :id class="hidden">
+          {{ text }}
+        </p>
+      </template>
+
+      <template #panel>
+        <p class="px-2 py-1 text-sm font-normal text-white">
+          {{ text }}
+        </p>
+      </template>
+    </UPopover>
+  </div>
+</template>

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -94,7 +94,11 @@ export default {
     close: 'Close',
     openHelpDocs: 'Read the Overview',
     downloadReceipt: 'Download Receipt',
-    downloadReport: 'Download Report'
+    downloadReport: 'Download Report',
+    info: {
+      show: 'Show information',
+      hide: 'Hide information'
+    }
   },
   currency: {
     cad: 'CAD',
@@ -229,7 +233,10 @@ export default {
       title: 'File Your BC Annual Report - Service BC Annual Report',
       h1: '{year} Annual Report',
       h2: 'Annual Report for: {name}',
-      reviewAndConfirm: 'Please review the Office Addresses and Current Directors below.',
+      reviewAndConfirm: {
+        main: 'Please review the office addresses and current directors below. This information needs to be correct before you proceed.',
+        help: 'Go to Corporate Online to update your office addresses and directors, then come back here to file your annual report. If an office address was updated, you will need to wait until the next day to complete your annual report.'
+      },
       form: {
         agmStatus: {
           question: 'The {year} Annual General Meeting (AGM) status of this business',

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -263,7 +263,7 @@ export default {
           link: 'See the {link} for more information.'
         },
         certify: {
-          question: 'certify all information about the Office Addresses and Current Directors is correct.',
+          question: 'I {boldStart}{name}{boldEnd} certify all information about the Office Addresses and Current Directors is correct.',
           error: 'You must confirm to continue'
         }
       },

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -258,7 +258,10 @@ export default {
           format: 'Format: YYYY-MM-DD',
           error: 'You must select a resolution date if the board voted to not hold an AGM'
         },
-        complianceWarning: '{boldStart}Important:{boldEnd} Please ensure that you meet the AGM compliance before filing your annual report.',
+        complianceWarning: {
+          main: '{boldStart}Important:{boldEnd} Please ensure that you meet the AGM compliance before filing your annual report.',
+          link: 'See the {link} for more information.'
+        },
         certify: {
           question: 'certify all information about the Office Addresses and Current Directors is correct.',
           error: 'You must confirm to continue'

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -94,7 +94,11 @@ export default {
     close: 'Fermer',
     openHelpDocs: "Lire la Vue d'Ensemble",
     downloadReceipt: 'Télécharger le Reçu',
-    downloadReport: 'Télécharger le Rapport'
+    downloadReport: 'Télécharger le Rapport',
+    info: {
+      show: 'Afficher les informations',
+      hide: 'Masquer les informations'
+    }
   },
   currency: {
     cad: 'CAD',
@@ -229,7 +233,7 @@ export default {
       title: 'Déposez votre rapport annuel - Rapport Annuel de Service CB',
       h1: 'Rapport Annuel {year}',
       h2: 'Rapport Annuel pour: {name}',
-      reviewAndConfirm: 'Veuillez confirmer les adresses des bureaux et les administrateurs actuels ci-dessous.',
+      reviewAndConfirm: 'Veuillez consulter les adresses des bureaux et les administrateurs actuels ci-dessous. Ces informations doivent être correctes avant de continuer.',
       form: { // TODO: review annual report form translations
         agmStatus: {
           question: "Le statut de l'Assemblée Générale Annuelle (AGA) {year} de cette entreprise",

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -233,7 +233,10 @@ export default {
       title: 'Déposez votre rapport annuel - Rapport Annuel de Service CB',
       h1: 'Rapport Annuel {year}',
       h2: 'Rapport Annuel pour: {name}',
-      reviewAndConfirm: 'Veuillez consulter les adresses des bureaux et les administrateurs actuels ci-dessous. Ces informations doivent être correctes avant de continuer.',
+      reviewAndConfirm: {
+        main: 'Veuillez consulter les adresses des bureaux et les administrateurs actuels ci-dessous. Ces informations doivent être correctes avant de continuer.',
+        help: 'Accédez à Corporate Online pour mettre à jour les adresses de vos bureaux et celles de vos administrateurs, puis revenez ici pour déposer votre rapport annuel. Si une adresse de bureau a été mise à jour, vous devrez attendre le lendemain pour compléter votre rapport annuel.'
+      },
       form: { // TODO: review annual report form translations
         agmStatus: {
           question: "Le statut de l'Assemblée Générale Annuelle (AGA) {year} de cette entreprise",
@@ -255,7 +258,10 @@ export default {
           format: 'Format: AAAA-MM-JJ',
           error: "Vous devez sélectionner une date de résolution si le conseil d'administration a voté pour ne pas tenir d'AGA."
         },
-        complianceWarning: "{boldStart}Important:{boldEnd} Veuillez vous assurer que vous respectez les exigences de l'AGA avant de déposer votre rapport annuel.",
+        complianceWarning: {
+          main: "{boldStart}Important:{boldEnd} Veuillez vous assurer que vous respectez les exigences de l'AGA avant de déposer votre rapport annuel.",
+          link: "Consultez la {link} pour plus d'informations."
+        },
         certify: {
           question: 'certifie que toutes les informations concernant les adresses des bureaux et les directeurs actuels sont exactes.',
           error: 'Vous devez confirmer pour continuer'

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -263,7 +263,7 @@ export default {
           link: "Consultez la {link} pour plus d'informations."
         },
         certify: {
-          question: 'certifie que toutes les informations concernant les adresses des bureaux et les directeurs actuels sont exactes.',
+          question: 'Je {boldStart}{name}{boldEnd} certifie que toutes les informations concernant les adresses des bureaux et les directeurs actuels sont exactes.',
           error: 'Vous devez confirmer pour continuer'
         }
       },

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "3.2.6",
+  "version": "3.3.0",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -273,7 +273,19 @@ if (import.meta.client) {
               :ui="{ description: 'mt-1 text-sm leading-4 opacity-90 text-bcGovColor-midGray', variant: { subtle: 'ring-2' }, rounded: 'rounded-none' }"
             >
               <template #description>
-                <SbcI18nBold translation-path="page.annualReport.form.complianceWarning" />
+                <div class="flex flex-col gap-1">
+                  <SbcI18nBold translation-path="page.annualReport.form.complianceWarning.main" />
+                  <i18n-t keypath="page.annualReport.form.complianceWarning.link" tag="span" scope="global">
+                    <template #link>
+                      <a class="text-sm text-bcGovBlue-500 underline" target="_blank" href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/02057_06#section182">
+                        Business Corporations ACT
+                      </a>
+                      <span class="ml-1 inline-flex pb-1 align-middle">
+                        <UIcon name="i-mdi-open-in-new" class="size-4 shrink-0 text-bcGovBlue-500" />
+                      </span>
+                    </template>
+                  </i18n-t>
+                </div>
               </template>
             </UAlert>
 

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormError, FormSubmitEvent } from '#ui/types'
 import { handleFormErrorEvent } from '~/utils/form/handleFormErrorEvent'
-import { UCheckbox, UTooltip, UForm } from '#components'
+import { UCheckbox, UForm } from '#components'
 const { t } = useI18n()
 const localePath = useLocalePath()
 const keycloak = useKeycloak()
@@ -37,7 +37,6 @@ const options = [
 
 const arFormRef = ref<InstanceType<typeof UForm> | null>(null)
 const checkboxRef = ref<InstanceType<typeof UCheckbox> | null>(null)
-const tooltipRef = ref<InstanceType<typeof UTooltip> | null>(null)
 const selectedRadio = ref<string | null>(null)
 
 // form state
@@ -221,33 +220,29 @@ if (import.meta.client) {
             @error="handleFormErrorEvent"
           >
             <UFormGroup name="radioGroup">
+              <!-- label for visual -->
               <template #label>
-                <div class="flex items-start gap-1">
-                  <span>{{ $t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear }) }}</span>
-                  <!-- TODO: investigate better i18n/mobile tooltip options -->
-                  <UTooltip
-                    ref="tooltipRef"
-                    :text="$t('page.annualReport.form.agmStatus.tooltip')"
-                    :popper="{ arrow: true, placement: 'auto' }"
-                    tabindex="0"
-                    @focus="() => tooltipRef?.onMouseEnter()"
-                    @blur="() => tooltipRef?.onMouseLeave()"
-                  >
-                    <UIcon
-                      name="i-mdi-info-outline"
-                      class="size-6 shrink-0 text-bcGovColor-activeBlue [@media(pointer:coarse)]:hidden"
-                    />
-                  </UTooltip>
-                </div>
+                <span>{{ $t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear }) }}
+                  <SbcTooltip id="agm-status-tooltip" :text="$t('page.annualReport.form.agmStatus.tooltip')" />
+                </span>
               </template>
-
-              <URadioGroup
-                v-model="selectedRadio"
-                :legend="$t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear })"
-                :options
-                :ui="{ fieldset: 'space-y-2', legend: 'sr-only' }"
-                :ui-radio="{ label: 'text-base font-medium text-bcGovColor-midGray dark:text-gray-200', wrapper: 'relative flex items-center' }"
-              />
+              <fieldset>
+                <!-- legend for accessibility -->
+                <legend class="sr-only">
+                  {{ $t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear }) }}
+                </legend>
+                <!-- use radio instead of radio group, allows aria-describedby property -->
+                <div class="space-y-1">
+                  <URadio
+                    v-for="option in options"
+                    :key="option.value"
+                    v-model="selectedRadio"
+                    v-bind="option"
+                    aria-describedby="agm-status-tooltip"
+                    :ui="{ label: 'text-base font-medium text-bcGovColor-midGray dark:text-gray-200', wrapper: 'relative flex items-center' }"
+                  />
+                </div>
+              </fieldset>
             </UFormGroup>
 
             <!-- AGM Date -->
@@ -304,7 +299,8 @@ if (import.meta.client) {
         </SbcPageSectionCard>
 
         <h2 class="text-lg font-semibold text-bcGovColor-darkGray">
-          {{ $t('page.annualReport.reviewAndConfirm') }}
+          {{ $t('page.annualReport.reviewAndConfirm.main') }}
+          <SbcTooltip :text="$t('page.annualReport.reviewAndConfirm.help')" />
         </h2>
 
         <SbcPageSectionCard

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -347,9 +347,7 @@ if (import.meta.client) {
               v-model="arData.officeAndDirectorsConfirmed"
             >
               <template #label>
-                <span>{{ $t('words.i') }}</span>
-                <span class="mx-1 font-semibold">{{ parseSpecialChars(keycloak.kcUser.value.fullName, 'USER').toLocaleUpperCase($i18n.locale) }}</span>
-                <span>{{ $t('page.annualReport.form.certify.question') }}</span>
+                <SbcI18nBold translation-path="page.annualReport.form.certify.question" :name="parseSpecialChars(keycloak.kcUser.value.fullName, 'USER').toLocaleUpperCase($i18n.locale)" />
               </template>
             </UCheckbox>
           </UFormGroup>


### PR DESCRIPTION
issues: #257 #258 

- add link in compliance warning when choosing, 'agm to be held'
- add tooltip info icon to 'Please review the office addresses....' text
- update i18n bold helper component to accept any props
- create tooltip component for hover on desktop or touch on mobile, can also focus and open with keyboard
- add translations for tooltip + compliance warning text
- add aria-describedby prop to radio group from tooltip text on agm status question
- fix error in addresses table if registeredOffice or recordsOffice is undefined

<img width="1489" alt="Screenshot 2024-07-08 at 9 40 31 AM" src="https://github.com/bcgov/business-ar/assets/73151365/8c307ff2-b3ee-47fa-99f8-7de522e1f09d">
