### PR TITLE
Content links

### DIFF
--- a/web/site/components/Sbc/Help/Content.vue
+++ b/web/site/components/Sbc/Help/Content.vue
@@ -2,5 +2,5 @@
 const helpDocs = inject('sbc-bar-help-docs')
 </script>
 <template>
-  <ContentRenderer :value="helpDocs" class="prose prose-bcGov prose-h2:mt-4 prose-h2:mb-2 min-w-full break-words text-left leading-snug" />
+  <ContentRenderer :value="helpDocs" class="prose prose-bcGov prose-a:break-all prose-h2:mt-4 prose-h2:mb-2 min-w-full max-w-[95vw] overflow-hidden break-words text-left leading-snug" />
 </template>

--- a/web/site/components/Sbc/Help/Content.vue
+++ b/web/site/components/Sbc/Help/Content.vue
@@ -2,5 +2,5 @@
 const helpDocs = inject('sbc-bar-help-docs')
 </script>
 <template>
-  <ContentRenderer :value="helpDocs" class="prose prose-bcGov prose-a:break-all prose-h2:mt-4 prose-h2:mb-2 min-w-full max-w-[95vw] overflow-hidden break-words text-left leading-snug" />
+  <ContentRenderer :value="helpDocs" class="prose prose-bcGov prose-h2:mt-4 prose-h2:mb-2 min-w-full max-w-[95vw] overflow-hidden break-words text-left leading-snug" />
 </template>

--- a/web/site/components/content/ProseA.vue
+++ b/web/site/components/content/ProseA.vue
@@ -28,16 +28,12 @@ function resolvePath () {
 </script>
 
 <template>
-  <UButton
-    :to="resolvePath()"
-    :target
-    :download
-    variant="link"
-    class="-mx-2 -my-4"
-    size="sm"
-    trailing
-    :icon="target === '_blank' ? 'i-mdi-open-in-new' : ''"
-  >
-    <slot />
-  </UButton>
+  <span>
+    <a class="text-bcGovBlue-500 underline" :target :download :href="resolvePath()">
+      <slot />
+    </a>
+    <span v-if="target === '_blank'" class="ml-1 inline-flex pb-1 align-middle">
+      <UIcon name="i-mdi-open-in-new" class="size-4 shrink-0 text-bcGovBlue-500" />
+    </span>
+  </span>
 </template>

--- a/web/site/content/en-CA/index/2.md
+++ b/web/site/content/en-CA/index/2.md
@@ -1,6 +1,6 @@
 There was an issue processing your request. If you believe this is an error, please try again or contact BC Registries for support.
 
 **BC Registries and Online Services** <br>
-Toll Free: 1-877-526-1526 <br>
-Victoria Office: 250-387-7848 <br>
+Toll Free: [1-877-526-1526](tel:1-877-526-1526) <br>
+Victoria Office: [250-387-7848](tel:1-250-387-7848) <br>
 Email: BCRegistries@gov.bc.ca

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -298,7 +298,7 @@ export default {
       noFee: 'No Fee',
       priorityFees: 'Priority Fees',
       futureEffectiveFees: 'Future Effective Fees',
-      serviceFees: 'Service Fees',
+      serviceFees: 'Service Fee',
       itemLabels: {
         TEST: 'This is test entry',
         REGSIGIN: 'Significant Individual Change',

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
issue #268 
- update prose-a component to wrap text instead of creating a new line.
- update 'Service Fees' to 'Service Fee' in fee widget
- update contact info phone numbers to be clickable

Before (note the gap on the line above the link with the icon): 
![Screenshot 2024-07-08 at 11 08 17 AM](https://github.com/bcgov/business-ar/assets/73151365/8a1aaba1-6403-4933-9e9e-30b929547824)

After: 
<img width="524" alt="Screenshot 2024-07-08 at 11 05 57 AM" src="https://github.com/bcgov/business-ar/assets/73151365/f2526cb8-6d53-4533-86bd-1da6fe9d755b">


Partial: https://app.zenhub.com/workspaces/annual-report-filing-for-corporations-661483a4f4f833001637ec44/issues/zh/39
<img width="302" alt="Screenshot 2024-07-08 at 11 16 21 AM" src="https://github.com/bcgov/business-ar/assets/73151365/c259498c-c27d-4291-a881-2a06171eb7d2">

Contact info links:
before:
<img width="660" alt="Screenshot 2024-07-08 at 11 40 37 AM" src="https://github.com/bcgov/business-ar/assets/73151365/60c68aaa-1c68-4332-9de2-788e5aec6215">

after:
<img width="1591" alt="Screenshot 2024-07-08 at 11 42 06 AM" src="https://github.com/bcgov/business-ar/assets/73151365/9b0189af-3980-405a-920d-8e557da9a467">

