### PR TITLE
feat: add mobile view for review page

### DIFF
--- a/web/site/components/Sbc/PageSection/Card.vue
+++ b/web/site/components/Sbc/PageSection/Card.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   heading: string
   headingIcon?: string
   headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  isMobile?: boolean
+  showContent?: boolean
 }>()
+
+defineEmits(['toggleContent'])
+
 </script>
 <template>
   <UCard
@@ -17,17 +22,29 @@ defineProps<{
     }"
   >
     <template #header>
-      <component
-        :is="headingLevel || 'h2'"
-        class="flex items-center gap-2 font-semibold text-bcGovColor-darkGray dark:text-white"
-      >
-        <UIcon
-          v-if="headingIcon"
-          :name="headingIcon"
-          class="size-6 shrink-0 text-bcGovColor-activeBlue"
-        />
-        <span>{{ heading }}</span>
-      </component>
+      <div class="flex w-full items-center justify-between">
+        <component
+          :is="headingLevel || 'h2'"
+          :class="[
+            'flex items-center gap-2 text-bcGovColor-darkGray dark:text-white',
+            { 'text-2xl font-bold': isMobile, 'text-lg font-semibold': !isMobile }
+          ]"
+        >
+          <UIcon
+            v-if="headingIcon"
+            :name="headingIcon"
+            class="size-6 shrink-0 text-bcGovColor-activeBlue"
+          />
+          <span>{{ heading }}</span>
+        </component>
+        <!-- Dropdown button for mobile screens -->
+        <button v-if="isMobile && showContent !== undefined" @click="$emit('toggleContent')">
+          <UIcon
+            :name="props.showContent ? 'i-mdi-chevron-up' : 'i-mdi-chevron-down'"
+            class="size-6 shrink-0 text-bcGovColor-activeBlue"
+          />
+        </button>
+      </div>
     </template>
     <slot />
   </UCard>

--- a/web/site/components/Sbc/Table/Address/index.vue
+++ b/web/site/components/Sbc/Table/Address/index.vue
@@ -43,22 +43,53 @@ const addresses = computed(() => {
 })
 </script>
 <template>
-  <UTable
-    :rows="addresses"
-    :columns
-    :empty-state="{ icon: 'i-heroicons-circle-stack-20-solid', label: $t('page.annualReport.noAddresses') }"
-  >
-    <template #mailingAddress-data="{ row }">
-      <SbcAddressDisplay :address="row.mailingAddress" />
-    </template>
+  <div>
+    <!-- Desktop / Tablet View -->
+    <div class="hidden sm:block">
+      <UTable
+        :rows="addresses"
+        :columns
+        :empty-state="{ icon: 'i-heroicons-circle-stack-20-solid', label: $t('page.annualReport.noAddresses') }"
+      >
+        <template #mailingAddress-data="{ row }">
+          <SbcAddressDisplay :address="row.mailingAddress" />
+        </template>
 
-    <template #name-data="{ row }">
-      <span class="font-semibold text-bcGovColor-darkGray"> {{ row.name }} </span>
-    </template>
+        <template #name-data="{ row }">
+          <span class="font-semibold text-bcGovColor-darkGray"> {{ row.name }} </span>
+        </template>
 
-    <template #deliveryAddress-data="{ row }">
-      <SbcAddressDisplay v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])" :address="row.deliveryAddress" />
-      <span v-else> {{ $t('labels.sameAsMailAddress') }} </span>
-    </template>
-  </UTable>
+        <template #deliveryAddress-data="{ row }">
+          <SbcAddressDisplay v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])" :address="row.deliveryAddress" />
+          <span v-else> {{ $t('labels.sameAsMailAddress') }} </span>
+        </template>
+      </UTable>
+    </div>
+
+    <!-- Mobile View -->
+    <div class="block sm:hidden">
+      <div v-for="(row, index) in addresses" :key="index" :class="{'pt-3': index !== 0}">
+        <div class="text-lg font-bold">
+          {{ t('labels.office') }}
+        </div>
+
+        <div class="px-4 pt-2">
+          <div class="font-bold">
+            {{ t('labels.mailingAddress') }}
+          </div>
+          <SbcAddressDisplay :address="row.mailingAddress" />
+        </div>
+
+        <div class="px-4 pt-3">
+          <div class="font-bold">
+            {{ t('labels.deliveryAddress') }}
+          </div>
+          <div v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])">
+            <SbcAddressDisplay :address="row.deliveryAddress" />
+          </div>
+          <span v-else>{{ $t('labels.sameAsMailAddress') }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>

--- a/web/site/components/Sbc/Table/Directors/index.vue
+++ b/web/site/components/Sbc/Table/Directors/index.vue
@@ -39,22 +39,60 @@ const parties = computed(() => {
 })
 </script>
 <template>
-  <UTable
-    :rows="parties"
-    :columns
-    :empty-state="{ icon: 'i-heroicons-circle-stack-20-solid', label: $t('page.annualReport.noDirectors') }"
-  >
-    <template #mailingAddress-data="{ row }">
-      <SbcAddressDisplay :address="row.mailingAddress" />
-    </template>
+  <div>
+    <!-- Desktop / Tablet View -->
+    <div class="hidden sm:block">
+      <UTable
+        :rows="parties"
+        :columns
+        :empty-state="{ icon: 'i-heroicons-circle-stack-20-solid', label: $t('page.annualReport.noDirectors') }"
+      >
+        <template #mailingAddress-data="{ row }">
+          <SbcAddressDisplay :address="row.mailingAddress" />
+        </template>
 
-    <template #name-data="{ row }">
-      <span class="font-semibold text-bcGovColor-darkGray"> {{ parseSpecialChars(row.name).toLocaleUpperCase($i18n.locale) }} </span>
-    </template>
+        <template #name-data="{ row }">
+          <span class="font-semibold text-bcGovColor-darkGray"> {{ parseSpecialChars(row.name).toLocaleUpperCase($i18n.locale) }} </span>
+        </template>
 
-    <template #deliveryAddress-data="{ row }">
-      <SbcAddressDisplay v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])" :address="row.deliveryAddress" />
-      <span v-else> {{ $t('labels.sameAsMailAddress') }} </span>
-    </template>
-  </UTable>
+        <template #deliveryAddress-data="{ row }">
+          <SbcAddressDisplay v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])" :address="row.deliveryAddress" />
+          <span v-else> {{ $t('labels.sameAsMailAddress') }} </span>
+        </template>
+      </UTable>
+    </div>
+
+    <!-- Mobile View -->
+    <div class="block sm:hidden">
+      <div v-for="(row, index) in parties" :key="index" :class="{'pt-3': index !== 0}">
+        <div class="text-lg font-bold">
+          {{ parseSpecialChars(row.name).toLocaleUpperCase($i18n.locale) }}
+        </div>
+
+        <div class="px-4 pt-2">
+          <div class="font-bold">
+            {{ t('labels.mailingAddress') }}
+          </div>
+          <SbcAddressDisplay :address="row.mailingAddress" />
+        </div>
+
+        <div class="px-4 pt-3">
+          <div class="font-bold">
+            {{ t('labels.deliveryAddress') }}
+          </div>
+          <div v-if="!deepEqual(row.mailingAddress, row.deliveryAddress, ['addressId'])">
+            <SbcAddressDisplay :address="row.deliveryAddress" />
+          </div>
+          <span v-else>{{ $t('labels.sameAsMailAddress') }}</span>
+        </div>
+
+        <div class="px-4 pt-3">
+          <div class="font-bold">
+            {{ t('labels.effectiveDates') }}
+          </div>
+          {{ row.effectiveDates }}
+        </div>
+      </div>
+    </div>
+  </div>
 </template>

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -39,6 +39,11 @@ const arFormRef = ref<InstanceType<typeof UForm> | null>(null)
 const checkboxRef = ref<InstanceType<typeof UCheckbox> | null>(null)
 const selectedRadio = ref<string | null>(null)
 
+// Mobile View dropdowns
+const isMobile = ref(false)
+const showAddressesRef = ref<boolean>(true)
+const showDirectorsRef = ref<boolean>(true)
+
 // form state
 const arData = reactive<{ agmDate: Date | null, voteDate: Date | null, officeAndDirectorsConfirmed: boolean}>({
   agmDate: null,
@@ -140,6 +145,19 @@ watch(selectedRadio, (newVal) => {
     arData.voteDate = null
     arData.officeAndDirectorsConfirmed = false
   }
+})
+
+function handleResize () {
+  isMobile.value = window.innerWidth < 640
+}
+
+onMounted(() => {
+  window.addEventListener('resize', handleResize)
+  handleResize()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
 })
 
 // init page state in setup lifecycle
@@ -319,22 +337,30 @@ if (import.meta.client) {
           :heading="$t('words.addresses')"
           heading-icon="i-mdi-map-marker"
           heading-level="h3"
+          :is-mobile="isMobile"
+          :show-content="showAddressesRef"
+          @toggle-content="showAddressesRef = !showAddressesRef"
         >
-          <SbcTableAddress :offices="busStore.fullDetails.offices" />
+          <SbcTableAddress v-if="showAddressesRef || !isMobile" :offices="busStore.fullDetails.offices" />
         </SbcPageSectionCard>
 
         <SbcPageSectionCard
           :heading="$t('words.directors')"
           heading-icon="i-mdi-account-multiple-plus"
           heading-level="h3"
+          :is-mobile="isMobile"
+          :show-content="showDirectorsRef"
+          @toggle-content="showDirectorsRef = !showDirectorsRef"
         >
-          <SbcTableDirectors :directors="busStore.fullDetails.parties" />
+          <SbcTableDirectors v-if="showDirectorsRef || !isMobile" :directors="busStore.fullDetails.parties" />
         </SbcPageSectionCard>
 
         <SbcPageSectionCard
           :heading="$t('words.confirm')"
           heading-icon="i-mdi-text-box-check"
           heading-level="h3"
+          :is-mobile="isMobile"
+          :show-content="undefined"
         >
           <UFormGroup
             :ui="{


### PR DESCRIPTION
Updated the review page's UI to better handle mobile screens.
 - Addresses Section
     1. Made header text larger and more bold when on mobile
     2. Made section have a dropdown that toggles whether addresses are shown when on mobile
     3. Changed formatting of addresses to be a single row on mobile
 - Directors Section
     1. Made header text larger and more bold when on mobile
     2. Made section have a dropdown that toggles whether directors are shown when on mobile
     3. Changed formatting of directors to be a single row on mobile
 - Confirmation Section
    1. Made header text larger and more bold when on mobile