### PR TITLE
fix: make completion date the same as payment completion date

### DIFF
--- a/api/src/business_ar_api/services/filing_service.py
+++ b/api/src/business_ar_api/services/filing_service.py
@@ -182,6 +182,6 @@ class FilingService:
         for colin_id in colin_ids:
             filing.colin_event_ids.append(ColinEventId(colin_event_id=colin_id))
         filing.status = FilingModel.Status.COMPLETED
-        filing.completion_date = datetime.utcnow()
+        filing.completion_date = filing.payment_completion_date
         filing.save()
         return filing


### PR DESCRIPTION
I believe the issue here is below:

First a filing is made and when the payment is complete the `payment completion date`  which matches to `effective date` is set. 
https://github.com/bcgov/business-ar/blob/main/api/src/business_ar_api/services/report_service.py#L135

Second, the `process_paid_filings` job later runs and calls `complete_filing()`.
https://github.com/bcgov/business-ar/blob/main/jobs/process_paid_filings/src/process_paid_filings/job.py#L196
https://github.com/bcgov/business-ar/blob/main/api/src/business_ar_api/services/filing_service.py#L185

The `complete_filing()` call sets the date again causing the difference in ~2-5 minutes in these date fields. 

This PR changes this logic so that when a filing is complete it sets the `completion_date` to be the same as the `payment_completion_date`.