### PR TITLE
fix: sync filing, payment_completion, and completion dates

### DIFF
--- a/api/src/business_ar_api/services/filing_service.py
+++ b/api/src/business_ar_api/services/filing_service.py
@@ -182,6 +182,8 @@ class FilingService:
         for colin_id in colin_ids:
             filing.colin_event_ids.append(ColinEventId(colin_event_id=colin_id))
         filing.status = FilingModel.Status.COMPLETED
-        filing.completion_date = filing.payment_completion_date
+        filing.filing_date = datetime.utcnow()
+        filing.completion_date = filing.filing_date
+        filing.payment_completion_date = filing.filing_date
         filing.save()
         return filing


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/business-ar/307

Made these dates so they are the same in GCP database.
1. Filing_date
2. Completion_date
3. Payment_completion_date
