### PR TITLE
updated update_ar_indicator_in_colin method

### DIFF
--- a/jobs/ar-reminder/src/ar_reminder/job.py
+++ b/jobs/ar-reminder/src/ar_reminder/job.py
@@ -113,10 +113,7 @@ def send_email(app: Flask, notify_body: dict, token: str):
 
 def update_ar_indicator_in_colin(app: Flask, legal_type: str, identifier: str, token: str):
     """Calls Colin API in Lear: turns off ar reminder flag and insert into set_ar_to_no"""
-    url = (
-        f'{app.config["COLIN_API_URL"]}/{app.config["COLIN_API_VERSION"]}/'
-        f'businesses/{legal_type}/{identifier}/filings/reminder'
-    )
+    url = f'{app.config["COLIN_API_URL"]}/businesses/{legal_type}/{identifier}/filings/reminder'
     headers = {
         **CONTENT_TYPE_JSON,
         "Authorization": AuthHeaderType.BEARER.value.format(token),


### PR DESCRIPTION
## Description
This PR updates the `update_ar_indicator_in_colin` function to correctly call the newly added Colin API endpoint for updating AR reminder status.

## Changes
- Removed the usage of `COLIN_API_VERSION` from the URL construction in `update_ar_indicator_in_colin` function
- Updated the URL format to match the new API endpoint structure