### PR TITLE
fix: convert founding date back to pacific time for Colin to proces

### DIFF
--- a/jobs/process_paid_filings/src/process_paid_filings/job.py
+++ b/jobs/process_paid_filings/src/process_paid_filings/job.py
@@ -215,7 +215,10 @@ def run():
                 # The Colin API sends us the founding date in UTC, but we need to convert it
                 # back to the local Pacific Time zone to ensure the last_ar_filed_date reflects
                 # the same calendar day locally as when the business was founded.
-                utc_founding_date = datetime.fromisoformat(filing["filing"]["business"]["foundingDate"]).replace(tzinfo=pytz.utc)
+                utc_founding_date = (
+                    datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
+                    .replace(tzinfo=pytz.utc)
+                )
                 pacific_founding_date = utc_founding_date.astimezone(pytz.timezone('America/Los_Angeles'))
                 filing["filing"]["business"]["foundingDate"] = pacific_founding_date.isoformat()
 

--- a/jobs/process_paid_filings/src/process_paid_filings/job.py
+++ b/jobs/process_paid_filings/src/process_paid_filings/job.py
@@ -17,6 +17,8 @@ import logging
 import json
 import os
 from typing import List
+from datetime import datetime
+import pytz
 
 import requests
 import sentry_sdk
@@ -208,6 +210,14 @@ def run():
                 filing["filing"]["header"]["certifiedBy"] = filing["filing"]["header"]["certifiedByDisplayName"]
                 filing["filing"]["header"]["submitter"] = filing["filing"]["header"]["certifiedByDisplayName"]
                 filing["filing"]["header"]["source"] = "BAR"
+
+                # Convert the founding date from UTC to Pacific Time.
+                # The Colin API sends us the founding date in UTC, but we need to convert it
+                # back to the local Pacific Time zone to ensure the last_ar_filed_date reflects
+                # the same calendar day locally as when the business was founded.
+                utc_founding_date = datetime.fromisoformat(filing["filing"]["business"]["foundingDate"]).replace(tzinfo=pytz.utc)
+                pacific_founding_date = utc_founding_date.astimezone(pytz.timezone('America/Los_Angeles'))
+                filing["filing"]["business"]["foundingDate"] = pacific_founding_date.isoformat()
 
                 if identifier in corps_with_failed_filing:
                     # pylint: disable=no-member; false positive


### PR DESCRIPTION
**Ticket:** https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/business-ar/318

The problem with this one was that `last_ar_filed_dt` in the `corporation` table is sometimes one day ahead. 

The reason why this is occurring:
   1. Colin API in Lear retrieves the `founding date` from Colin in Pacific Local Time and converts it to UTC time. (https://github.com/EPortman/lear/blob/main/colin-api/src/colin_api/models/business.py#L326)
   2.  Business AR receives this date in UTC time (https://github.com/EPortman/lear/blob/main/colin-api/src/colin_api/models/business.py#L326)
   3. Business AR then sends this date back to Colin API in the `process_paid_filings` job (https://github.com/EPortman/lear/blob/main/colin-api/src/colin_api/models/business.py#L326)
   4. Back in Lear, this date is taken and the hours, minutes, and seconds are stripped and the year is updated. (https://github.com/EPortman/lear/blob/main/colin-api/src/colin_api/models/filing.py#L1246)
   5. Since the date in Lear is pacific, and this time is in UTC, the date ends up being wrong if the time is after 16:00 (since 7 hours are added to convert)


Therefore to fix this issue, the `founding_date` is converted back to pacific Local Time so that the day always matches. 