### PR TITLE
Add functionality to file multipls ars

### DIFF
--- a/api/src/business_ar_api/models/filing.py
+++ b/api/src/business_ar_api/models/filing.py
@@ -132,6 +132,42 @@ class Filing(BaseModel):
         return query.all()
 
     @classmethod
+    def get_next_ar_fiscal_year(cls, business_id: str) -> int|None:
+        try:
+            status = [Filing.Status.COMPLETED, Filing.Status.PAID]
+            query = (
+                db.session.query(Filing)
+                .filter(Filing.business_id == int(business_id))
+                .filter(Filing.status.in_(status))
+                .order_by(Filing.fiscal_year.desc())
+            )
+            filings = query.all()
+            if filings:
+                return filings[0].fiscal_year + 1
+            return None
+        except Exception:
+            return None
+
+    @classmethod
+    def get_last_ar_filed_date(cls, business_id: str) -> str|None:
+        try:
+            status = [Filing.Status.COMPLETED, Filing.Status.PAID]
+            query = (
+                db.session.query(Filing)
+                .filter(Filing.business_id == int(business_id))
+                .filter(Filing.status.in_(status))
+                .order_by(Filing.fiscal_year.desc())
+            )
+            filings = query.all()
+            if filings:
+                filing_json = filings[0].filing_json
+                last_ar_date = filing_json.get('filing', {}).get('annualReport', {}).get('annualReportDate')
+                return last_ar_date
+            return None
+        except Exception:
+            return None
+
+    @classmethod
     def get_filing_by_payment_token(cls, payment_token: str) -> Filing:
         """Return filings by payment token."""
         return cls.query.filter_by(invoice_id=payment_token).one_or_none()

--- a/api/src/business_ar_api/resources/business.py
+++ b/api/src/business_ar_api/resources/business.py
@@ -69,6 +69,15 @@ def get_business_details_using_token(token):
         business_json["status"] = business_details_from_colin.get("business").get(
             "corpState"
         )
+        business_json["nextARYear"] = business_details_from_colin.get("business").get(
+            "nextARYear"
+        )
+        business_json["lastARDate"] =  business_details_from_colin.get("business").get(
+            "lastArDate"
+        )
+        business_json["foundingDate"] = business_details_from_colin.get("business").get(
+            "foundingDate"
+        )
         return business_json, HTTPStatus.OK
     else:
         return error_response("Invalid token.", HTTPStatus.BAD_REQUEST)

--- a/api/src/business_ar_api/services/business_service.py
+++ b/api/src/business_ar_api/services/business_service.py
@@ -99,10 +99,19 @@ class BusinessService:
                 0
             ].recipients
 
+        # Check for any unsynced filings in GCP and adjust
+        next_ar_year_gcp = FilingModel.get_next_ar_fiscal_year(business_id)
+        next_ar_adjustment = next_ar_year_gcp and next_ar_year_gcp > business_details["business"]["nextARYear"]
+        if next_ar_adjustment:
+            last_ar_date_gcp = FilingModel.get_last_ar_filed_date(business_id)
+            business_details["business"]["nextARYear"] = next_ar_year_gcp
+            business_details["business"]['lastArDate'] = datetime.strptime(last_ar_date_gcp, "%Y-%m-%d").strftime("%Y-%m-%d")
+
+        # Check for any future effective filings, ignoring ones due to unsynced filings in GCP
         fed_filings_endpoint = f"{current_app.config.get('COLIN_API_URL')}/businesses/{legal_type}/{colin_business_identifier}/filings/future"
         fed_filings = RestService.get(endpoint=fed_filings_endpoint, token=token).json()
         business_details["business"]["hasFutureEffectiveFilings"] = (
-            True if fed_filings and len(fed_filings) > 0 else False
+            True if fed_filings and len(fed_filings) > 0 and not next_ar_adjustment else False
         )
         return business_details
 
@@ -186,22 +195,23 @@ class BusinessService:
             business.identifier, business.legal_type, business.id
         ).get("business", {})
 
-        # Retrieve filings that are either incomplete, or drafts
-        pending_filings = FilingModel.find_business_filings_by_status(
+        # Retrieve Incomplete filings
+        incomplete_filings = FilingModel.find_business_filings_by_status(
             business.id,
             [
                 FilingModel.Status.DRAFT,
                 FilingModel.Status.PENDING,
-                FilingModel.Status.PAID,
             ],
         )
-        # Create a todo item for each pending filing
-        for filing in pending_filings:
+
+        # Create a todo item for each incomplete filing
+        for filing in incomplete_filings:
             filing_json = FilingSerializer.to_dict(filing)
             filing_json["filing"]["business"] = business_details_dict
             task = {"task": filing_json}
             tasks.append(task)
 
+        # Create a todo item for the next ar year
         if not tasks:
             next_ar_year = business_details_dict.get("nextARYear")
             if next_ar_year and next_ar_year <= datetime.utcnow().year:

--- a/web/site/components/Sbc/BusinessInfo.vue
+++ b/web/site/components/Sbc/BusinessInfo.vue
@@ -7,7 +7,12 @@ interface Item {
 const props = defineProps<{
   items: Item[]
   breakValue: 'sm' | 'md' | 'lg'
+  isSelectingFiling: boolean
+  arDueDates?: Date[]
+  isAuthenticated: boolean | undefined
 }>()
+
+const emit = defineEmits(['login'])
 
 const filteredItems = computed(() => {
   return props.items.filter(item => item.value !== null)
@@ -26,9 +31,13 @@ const breakpoint: Record<string, { [key: string]: string }> = {
   }
 }
 </script>
-<template>
+<template class="w-full">
   <div class="text-left">
     <!-- Desktop/Tablet View -->
+    <h1 v-if="props.isSelectingFiling" class="mb-5 text-2xl font-bold">
+      Log in to BC Registries
+    </h1>
+
     <table
       class="hidden w-fit table-auto"
       :class="breakpoint.table[breakValue]"
@@ -44,6 +53,52 @@ const breakpoint: Record<string, { [key: string]: string }> = {
         </tr>
       </tbody>
     </table>
+
+    <!-- Login Screen when a valid Nano ID has been entered -->
+    <div v-if="props.isSelectingFiling">
+      <hr class="my-4 border-t border-gray-300">
+      <h1 class="text-xl font-bold text-bcGovColor-darkGray">
+        Annual Reports
+      </h1>
+      <p class="mb-5 text-sm text-bcGovColor-midGray">
+        Reports must be filed from oldest to newest.
+      </p>
+
+      <!-- Iterate over the getDueReportDates -->
+      <div v-for="(date, index) in arDueDates" :key="index" class="mb-4">
+        <div class="flex items-center justify-between rounded-sm border border-red-500 bg-red-100 p-4">
+          <!-- First column: Red Alert Icon -->
+          <div class="flex items-center">
+            <UAlert
+              class="mr-2 size-7 shrink-0 !rounded-none !bg-transparent !p-0 !pt-1 text-red-500 !ring-0"
+              icon="i-mdi-alert"
+            />
+          </div>
+
+          <!-- Second column: Report Title and Date -->
+          <div class="flex-1">
+            <h2 class="text-lg font-bold text-bcGovColor-darkGray">
+              {{ date.getFullYear() }} BC Annual Report
+            </h2>
+            <p class="text-bcGovColor-midGray">
+              Due {{ date.toLocaleString('default', { month: 'long' }) }} {{ date.getDate() }}, {{ date.getFullYear() }}
+            </p>
+          </div>
+
+          <!-- Third column: Button -->
+          <div class="flex items-center">
+            <UButton
+              v-if="!isAuthenticated"
+              :label="$t('btn.loginBCSC')"
+              :disabled="index !== 0"
+              @click="emit('login')"
+            />
+          </div>
+        </div>
+      </div>
+      <SbcHelpTrigger />
+    </div>
+
     <!-- Mobile View -->
     <div
       v-for="item in filteredItems"

--- a/web/site/components/Sbc/FileAnotherReport.vue
+++ b/web/site/components/Sbc/FileAnotherReport.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+const props = defineProps<{
+  lastARCompletedYear: number
+  nextARYear: number | null
+  arDueDates: Date[]
+}>()
+const emit = defineEmits(['fileNextReport'])
+</script>
+
+<template>
+  <div class="w-full text-left">
+    <!-- Iterate over the getDueReportDates if there is another report to do -->
+    <template v-if="props.lastARCompletedYear && props.nextARYear">
+      <div v-for="(date, index) in arDueDates" :key="index" class="mb-4">
+        <div class="flex items-center justify-between rounded-sm border border-red-500 bg-red-100 p-4">
+          <!-- First column: Red Alert Icon -->
+          <div class="flex items-center">
+            <UAlert
+              class="mr-2 size-7 shrink-0 !rounded-none !bg-transparent !p-0 !pt-1 text-red-500 !ring-0"
+              icon="i-mdi-alert"
+            />
+          </div>
+          <!-- Second column: Report Title and Date -->
+          <div class="flex-1">
+            <h2 class="text-lg font-bold text-bcGovColor-darkGray">
+              {{ date.getFullYear() }} BC Annual Report
+            </h2>
+            <p class="text-bcGovColor-midGray">
+              Due {{ date.toLocaleString('default', { month: 'long' }) }} {{ date.getDate() }}, {{ date.getFullYear() }}
+            </p>
+          </div>
+          <!-- Third column: Button -->
+          <div class="flex items-center">
+            <UButton
+              :label="$t('btn.loginBCSC')"
+              :disabled="index !== 0"
+              @click="emit('fileNextReport')"
+            />
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/web/site/components/Sbc/Help/Trigger.vue
+++ b/web/site/components/Sbc/Help/Trigger.vue
@@ -3,26 +3,24 @@ const helpModal = useHelpModal()
 const localePath = useLocalePath()
 </script>
 <template>
-  <!-- open modal on touch screen, open new tab on desktop -->
-  <!-- hide modal trigger on desktop -->
-  <UButton
-    class="[@media(pointer:fine)]:hidden"
-    variant="outline"
-    :label="$t('btn.openHelpDocs')"
-    icon="i-mdi-help-circle-outline"
-    trailing
-    size="sm"
-    @click="helpModal.open()"
-  />
-  <!-- hide link on touch screen -->
-  <UButton
-    class="[@media(pointer:coarse)]:hidden"
-    variant="outline"
-    :label="$t('btn.openHelpDocs')"
-    icon="i-mdi-help-circle-outline"
-    trailing
-    size="sm"
+  <!-- Open modal on touch screen, open new tab on desktop -->
+  <!-- Hide modal trigger on desktop -->
+  <a
+    class="inline-flex items-center text-blue-600 underline [@media(pointer:fine)]:hidden"
+    href="#"
+    @click.prevent="helpModal.open()"
+  >
+    {{ $t('btn.openHelpDocs') }}
+    <i icon="i-mdi-open-in-new ml-1" />
+  </a>
+
+  <!-- Hide link on touch screen -->
+  <a
+    class="inline-flex items-center text-blue-600 underline [@media(pointer:coarse)]:hidden"
+    :href="localePath('/help')"
     target="_blank"
-    :to="localePath('/help')"
-  />
+  >
+    {{ $t('btn.openHelpDocs') }}
+    <i icon="i-mdi-open-in-new ml-1" />
+  </a>
 </template>

--- a/web/site/components/Sbc/NuxtContentCard.vue
+++ b/web/site/components/Sbc/NuxtContentCard.vue
@@ -46,7 +46,7 @@ watch([locale, routeWithoutLocale], () => {
 </script>
 <template>
   <UCard class="w-full" :data-testid="fullId">
-    <ContentRenderer v-if="data" :value="data" class="prose prose-bcGov text-left" />
+    <ContentRenderer v-if="data" :value="data" class="prose prose-bcGov w-full max-w-none text-left" />
     <div v-else class="text-center">
       <UIcon name="i-mdi-loading" class="animate-spin" />
     </div>

--- a/web/site/components/content/DocumentDownload.vue
+++ b/web/site/components/content/DocumentDownload.vue
@@ -6,13 +6,15 @@ const arStore = useAnnualReportStore()
 <template>
   <ClientOnly>
     <div
-      v-if="arStore.arFiling.filing.documents && arStore.arFiling.filing.documents.length > 0"
-      class="flex w-full items-center justify-center gap-2"
+      v-if="arStore.arFiling.filing?.documents && arStore.arFiling.filing.documents.length > 0"
+      class="flex w-full"
     >
       <UButton
         v-for="doc in arStore.arFiling.filing.documents"
         :key="doc.name"
-        size="sm"
+        size="lg"
+        color="blue"
+        variant="outline"
         icon="i-mdi-tray-arrow-down"
         :loading="arStore.loading"
         :label="doc.name === 'Receipt' ? $t('btn.downloadReceipt') : $t('btn.downloadReport')"

--- a/web/site/content/en-CA/index/1.md
+++ b/web/site/content/en-CA/index/1.md
@@ -1,2 +1,2 @@
-### To file Your BC Annual Report you'll need to:
-* Set up your digital ID using the <a href="https://id.gov.bc.ca/static/help/setup_app.html" target="_blank"> BC Services Card app </a>. This is a secure and easy way to prove who you are online, it protects your identity and makes sure no one else can access services as you.
+### No account?
+To file your annual report you’ll need to set up a <a href="https://id.gov.bc.ca/static/help/setup_app.html" target="_blank"> BC Services Card account </a>. This is a secure and easy way to prove who you are online, it protects your identity and makes sure no one else can access services as you. 

--- a/web/site/content/en-CA/submitted/platform-info.md
+++ b/web/site/content/en-CA/submitted/platform-info.md
@@ -1,3 +1,7 @@
+Want to share your feedback on the BC Annual Report? <a href="https://forms.gle/5niYLfjrymAqbLpr9" target="_blank">Complete our short survey now</a>.
+
+<hr style="margin: 0 0 20px 0;" />
+
 Did you know? The Business Registry will be expanding soon with even more self-serve digital services to help keep your business up to date. [Subscribe here for updates.](https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/news-updates/modernization)
 
 What is the Business Registry? The Business Registry is used to start a business and keep business records up to date. It's accessed from  [Service BC (SBC) Connect](https://www.bcregistry.gov.bc.ca) a digital platform that keeps you connected with BC Government services.

--- a/web/site/content/en-CA/submitted/success-text.md
+++ b/web/site/content/en-CA/submitted/success-text.md
@@ -1,6 +1,6 @@
-You have successfully filed your BC Annual Report on the Business Registry. 
-A receipt has been emailed to :BusinessEmail.
+<p style="font-size: 24px; font-weight: bold; margin: 0; padding: 0;">Your Receipt</p>
+
+You have successfully filed your BC Annual Report on the Business Registry. A receipt has been emailed to 
+:BusinessEmail.
 
 :DocumentDownload
-
-Want to share your feedback on the BC Annual Report? <a href="https://forms.gle/5niYLfjrymAqbLpr9" target="_blank">Complete our short survey now</a>.

--- a/web/site/interfaces/business.ts
+++ b/web/site/interfaces/business.ts
@@ -28,6 +28,9 @@ export interface BusinessNano {
   legalName: string
   legalType: string
   taxId: string | null
+  nextARYear: number
+  lastARDate: string | null
+  foundingDate: string
 }
 
 export interface BusinessFilingTask {

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -183,7 +183,8 @@ export default {
     },
     home: {
       title: 'Home - Service BC Annual Report',
-      h1: 'File your BC Annual Report'
+      h1: 'File your BC Annual Report',
+      h1Date: 'File your {date} BC Annual Report'
     },
     createAccount: {
       title: 'Account Creation - Service BC Annual Report',

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -183,7 +183,8 @@ export default {
     },
     home: {
       title: 'Accueil - Rapport Annuel de Service CB',
-      h1: 'Déposez votre rapport annuel de la Colombie-Britannique'
+      h1: 'Déposez votre rapport annuel de la Colombie-Britannique',
+      h1Date: 'Déposez votre rapport annuel de la Colombie-Britannique pour {date}'
     },
     createAccount: {
       title: 'Création de Compte - Rapport Annuel de Service CB',

--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -15,9 +15,9 @@ useHead({
   title: t('page.annualReport.title')
 })
 
-definePageMeta({
-  middleware: ['filing-paid', 'require-account']
-})
+// definePageMeta({
+//   middleware: ['filing-paid', 'require-account']
+// })
 
 // options for radio buttons
 const options = [
@@ -127,6 +127,15 @@ async function submitAnnualReport (event: FormSubmitEvent<any>) {
   }
 }
 
+// Compute latest next AR date as a string
+const nextArDate = computed(() => {
+  if (busStore.nextArDate) {
+    const date = new Date(busStore.nextArDate)
+    return !isNaN(date.getTime()) ? date.toISOString().slice(0, 10) : null
+  }
+  return null
+})
+
 // clear form errors anytime data changes
 watch(
   () => arData,
@@ -200,9 +209,11 @@ if (import.meta.client) {
 </script>
 <template>
   <ClientOnly>
-    <div v-show="!pageLoading" class="relative mx-auto flex w-full max-w-[1360px] flex-col gap-4 text-left sm:gap-4 md:flex-row md:gap-6">
+    <div v-show="!pageLoading" class="mx-auto flex w-3/4 items-center justify-center gap-4 text-left">
       <div class="flex w-full flex-col gap-6">
-        <SbcPageSectionH1 :heading="$t('page.annualReport.h1', { year: busStore.currentBusiness.nextARYear})" />
+        <SbcPageSectionH1
+          :heading="$t('page.annualReport.h1', { year: busStore.nextArYear})"
+        />
 
         <SbcAlert
           :show-on-category="[
@@ -221,8 +232,10 @@ if (import.meta.client) {
             :items="[
               { label: $t('labels.busName'), value: busStore.currentBusiness.legalName },
               { label: $t('labels.corpNum'), value: busStore.businessNano.identifier },
-              { label: $t('labels.arDate'), value: busStore.nextArDate },
+              { label: $t('labels.arDate'), value: nextArDate },
             ]"
+            :is-selecting-filing="false"
+            :is-authenticated="keycloak.isAuthenticated()"
           />
 
           <UDivider class="mb-4 mt-8" />
@@ -240,14 +253,14 @@ if (import.meta.client) {
             <UFormGroup name="radioGroup">
               <!-- label for visual -->
               <template #label>
-                <span>{{ $t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear }) }}
+                <span>{{ $t('page.annualReport.form.agmStatus.question', { year: busStore.nextArYear }) }}
                   <SbcTooltip id="agm-status-tooltip" :text="$t('page.annualReport.form.agmStatus.tooltip')" />
                 </span>
               </template>
               <fieldset>
                 <!-- legend for accessibility -->
                 <legend class="sr-only">
-                  {{ $t('page.annualReport.form.agmStatus.question', { year: busStore.currentBusiness.nextARYear }) }}
+                  {{ $t('page.annualReport.form.agmStatus.question', { year: busStore.nextArYear }) }}
                 </legend>
                 <!-- use radio instead of radio group, allows aria-describedby property -->
                 <div class="space-y-1">

--- a/web/site/pages/index.vue
+++ b/web/site/pages/index.vue
@@ -11,6 +11,7 @@ const accountStore = useAccountStore()
 const pageLoading = useState('page-loading')
 const alertStore = useAlertStore()
 const environment = useRuntimeConfig().public.environment
+const nextARYearRef = ref<number | null>(null)
 
 const nanoid = ref(route.query.nanoid || '')
 async function useNanoId () {
@@ -70,7 +71,10 @@ async function initPage () {
       // load business details if valid nano id and no user logged in (fresh start of flow)
       await busStore.getBusinessByNanoId(route.query.nanoid as string)
       pageLoading.value = false // only set false if not navigating to new page
-    } else { // throw error if no valid nano id
+    } else if (busStore.nanoID) {
+      // Business has already been loaded
+      pageLoading.value = false
+    } else {
       alertStore.addAlert({
         severity: 'error',
         category: AlertCategory.MISSING_TOKEN
@@ -83,6 +87,37 @@ async function initPage () {
   }
 }
 
+// Compute page heading based on next AR year
+const heading = computed(() => {
+  return nextARYearRef.value
+    ? t('page.home.h1Date', { date: nextARYearRef.value })
+    : t('page.home.h1')
+})
+
+// Compute latest next AR date as a string
+const nextArDate = computed(() => {
+  if (busStore.nextArDate) {
+    const date = new Date(busStore.nextArDate)
+    return !isNaN(date.getTime()) ? date.toISOString().slice(0, 10) : null
+  }
+  return null
+})
+
+// Watch next AR year for header reactivity
+watch(
+  () => busStore.nextArYear,
+  (newYear) => {
+    if (newYear) {
+      nextARYearRef.value = newYear
+    }
+  },
+  { immediate: true }
+)
+
+const handleLogin = () => {
+  keycloak.login()
+}
+
 // init page in setup lifecycle
 if (import.meta.client) {
   initPage()
@@ -91,9 +126,9 @@ if (import.meta.client) {
 <template>
   <!-- TODO: find hydration error only when being redirected from tos page -->
   <!-- must use v-show for nuxt content to prerender correctly -->
-  <div v-show="!pageLoading" class="mx-auto flex max-w-[95vw] flex-col items-center justify-center gap-4 text-center">
+  <div v-show="!pageLoading" class="mx-auto flex w-2/3 flex-col items-center justify-center gap-4 text-center">
     <ClientOnly>
-      <SbcPageSectionH1 :heading="$t('page.home.h1')" />
+      <SbcPageSectionH1 :heading="heading" />
 
       <SbcAlert
         :show-on-category="[
@@ -110,8 +145,6 @@ if (import.meta.client) {
         ]"
       />
 
-      <SbcHelpTrigger />
-
       <!-- show business details -->
       <UCard v-show="!deepEqual(busStore.businessNano, {})" class="w-full" data-testid="bus-details-card">
         <SbcBusinessInfo
@@ -120,7 +153,12 @@ if (import.meta.client) {
             { label: $t('labels.busName'), value: busStore.businessNano.legalName },
             { label: $t('labels.corpNum'), value: busStore.businessNano.identifier },
             { label: $t('labels.busNum'), value: busStore.businessNano.taxId ? `${busStore.businessNano.taxId.slice(0, 9)} ${busStore.businessNano.taxId.slice(9)}` : null },
+            { label: $t('labels.arDate'), value: nextArDate },
           ]"
+          :is-selecting-filing="true"
+          :ar-due-dates="busStore.getArDueDates()"
+          :is-authenticated="keycloak.isAuthenticated()"
+          @login="handleLogin"
         />
       </UCard>
     </ClientOnly>
@@ -133,13 +171,9 @@ if (import.meta.client) {
       route-suffix="2"
       :content="index2"
     />
+
+    <!-- Only displays in Dev and Test -->
     <ClientOnly>
-      <UButton
-        v-if="!keycloak.isAuthenticated() && !alertStore.hasAlerts"
-        :label="$t('btn.loginBCSC')"
-        icon="i-mdi-card-account-details-outline"
-        @click="keycloak.login"
-      />
       <div
         v-if="environment.includes('Development') || environment.includes('Test')"
         class="flex gap-2"

--- a/web/site/pages/submitted.vue
+++ b/web/site/pages/submitted.vue
@@ -2,6 +2,7 @@
 const { t } = useI18n()
 const route = useRoute()
 const busStore = useBusinessStore()
+const arStore = useAnnualReportStore()
 const localePath = useLocalePath()
 const pageLoading = useState('page-loading')
 
@@ -19,10 +20,16 @@ async function initPage () {
       throw new Error('Missing filing id in url.')
     } else {
       // check filing status details
-      await busStore.updatePaymentStatusForBusiness(route.query.filing_id as string)
+      if (!busStore.payStatus || busStore.payStatus !== 'PAID') {
+        await busStore.updatePaymentStatusForBusiness(route.query.filing_id as string)
+      }
+
       if (busStore.payStatus !== 'PAID') {
         return navigateTo(localePath('/annual-report'))
       }
+
+      // Filing was successful, load the next AR
+      await busStore.getBusinessTask()
     }
   } catch (e) {
     // go back to ar page if no filing id or error in the PUT request
@@ -33,26 +40,49 @@ async function initPage () {
   }
 }
 
+// Compute latest last AR date as a date
+const lastARDate = computed(() => {
+  if (busStore.lastArDate) {
+    return new Date(busStore.lastArDate)
+  }
+  return null
+})
+
+// Reset store and navigate back to filing page
+const handleFileNextReport = async () => {
+  arStore.$reset()
+  await nextTick()
+  return navigateTo(localePath('/annual-report'))
+}
+
 if (import.meta.client) {
   initPage()
 }
 </script>
+
 <template>
-  <div v-show="!pageLoading" class="mx-auto flex flex-col items-center justify-center gap-4 text-center">
-    <SbcPageSectionH1 class="flex items-center gap-2">
-      <span>{{ $t('page.submitted.h1') }}</span>
-      <UIcon
-        name="i-mdi-check-circle-outline"
-        class="size-10 shrink-0 text-outcomes-approved"
-      />
-    </SbcPageSectionH1>
-    <SbcAlert
-      :show-on-category="[
-        AlertCategory.INTERNAL_SERVER_ERROR,
-        AlertCategory.DOCUMENT_DOWNLOAD
-      ]"
-    />
-    <SbcNuxtContentCard id="submitted-success-text" route-suffix="/success-text" />
-    <SbcNuxtContentCard id="submitted-platform-info" route-suffix="/platform-info" />
-  </div>
+  <client-only>
+    <div v-if="!pageLoading && !deepEqual(busStore.businessNano, {})" class="mx-auto flex w-2/3 flex-col items-center justify-center gap-4 text-center">
+      <SbcPageSectionH1 class="mb-2 mt-3 flex items-center">
+        <span>{{ lastARDate!.getFullYear() }} {{ $t('page.submitted.h1') }}</span>
+        <UIcon name="i-mdi-check-circle-outline" class="size-10 shrink-0 text-outcomes-approved" />
+      </SbcPageSectionH1>
+
+      <SbcAlert :show-on-category="[AlertCategory.INTERNAL_SERVER_ERROR, AlertCategory.DOCUMENT_DOWNLOAD]" />
+
+      <SbcNuxtContentCard id="submitted-success-text" route-suffix="/success-text" />
+
+      <UCard class="w-full" data-testid="bus-details-card">
+        <SbcFileAnotherReport
+          :last-a-r-completed-year="lastARDate!.getFullYear()"
+          :next-a-r-year="busStore.nextArYear"
+          :ar-due-dates="busStore.getArDueDates()"
+          @file-next-report="handleFileNextReport"
+        />
+      </UCard>
+
+      <!-- Render platform info -->
+      <SbcNuxtContentCard id="submitted-platform-info" route-suffix="/platform-info" />
+    </div>
+  </client-only>
 </template>

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -14,6 +14,13 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         apiSuffix += `/${arFiling.value.filing.header.id}`
       }
 
+      // format the ar date to be sent
+      const arDate = busStore.nextArDate
+        ? (busStore.nextArDate instanceof Date
+            ? busStore.nextArDate.toISOString().slice(0, 10)
+            : new Date(busStore.nextArDate).toISOString().slice(0, 10))
+        : null
+
       const response = await useBarApi<ArFiling>(
         apiSuffix,
         {
@@ -21,11 +28,11 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
           body: {
             filing: {
               header: {
-                filingYear: busStore.currentBusiness.nextARYear
+                filingYear: busStore.nextArYear
               },
               annualReport: {
                 annualGeneralMeetingDate: arData.agmDate,
-                annualReportDate: busStore.nextArDate,
+                annualReportDate: arDate,
                 votedForNoAGM: arData.votedForNoAGM,
                 unanimousResolutionDate: arData.unanimousResolutionDate
               }

--- a/web/site/stores/business.ts
+++ b/web/site/stores/business.ts
@@ -5,12 +5,18 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
   const alertStore = useAlertStore()
 
   // store values
+  const nanoID = ref<string | null>(null)
   const loading = ref<boolean>(true)
   const currentBusiness = ref<BusinessFull>({} as BusinessFull)
   const fullDetails = ref<Business>({} as Business)
   const businessNano = ref<BusinessNano>({} as BusinessNano)
-  const nextArDate = ref<string>('')
   const payStatus = ref<string | null>(null)
+
+  // date values
+  const nextArYear = ref<number | null>(null)
+  const nextArDate = ref<Date | null>(null)
+  const lastArDate = ref<Date | null>(null)
+  const foundingDate = ref<Date | null>(null)
 
   // get basic business info by nano id
   async function getBusinessByNanoId (id: string): Promise<void> {
@@ -18,6 +24,16 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
       const response = await useBarApi<BusinessNano>(`/business/token/${id}`)
       if (response) {
         businessNano.value = response
+        nanoID.value = id
+        foundingDate.value = isoDateStringToLocalDate(response.foundingDate)
+        lastArDate.value = response.lastARDate ? dateStringToDate(response.lastARDate) : foundingDate.value
+        nextArYear.value = response.nextARYear || null
+
+        if (response.nextARYear) {
+          nextArDate.value = new Date(response.nextARYear, lastArDate.value!.getUTCMonth(), lastArDate.value!.getUTCDate())
+        } else {
+          nextArDate.value = null
+        }
       }
     } catch (e) {
       alertStore.addAlert({
@@ -34,6 +50,15 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
       const response = await useBarApi<Business>(`/business/${businessNano.value.identifier}`, {}, 'token')
       if (response) {
         fullDetails.value = response
+        foundingDate.value = isoDateStringToLocalDate(response.business.foundingDate)
+        lastArDate.value = response.business.lastArDate ? isoDateStringToLocalDate(response.business.lastArDate) : foundingDate.value
+        nextArYear.value = response.business.nextARYear || null
+
+        if (nextArYear.value) {
+          nextArDate.value = new Date(nextArYear.value, lastArDate.value!.getMonth(), lastArDate.value!.getDate())
+        } else {
+          nextArDate.value = null
+        }
       }
     } catch (e) {
       alertStore.addAlert({
@@ -74,20 +99,37 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
       throw new Error(`${bus.legalName || 'This business'} is not eligible to file an Annual Report`)
     }
 
-    // if no lastArDate, it means this is the companies first AR, so need to use founding date instead
-    if (!bus.lastArDate) {
-      nextArDate.value = addOneYear(bus.foundingDate)
-    } else {
-      nextArDate.value = addOneYear(bus.lastArDate!)
-    }
-
     // throw error if next ar date is in the future
-    if (new Date(nextArDate.value) > new Date()) {
+    if (!nextArYear.value || nextArYear.value! > new Date().getFullYear()) {
       alertStore.addAlert({
         severity: 'error',
         category: AlertCategory.FUTURE_FILING
       })
       throw new Error(`Annual Report not due until ${nextArDate.value}`)
+    }
+  }
+
+  // Returns the available report dates or an empty date array for the current business
+  function getArDueDates (): Date[] {
+    const reportDates: Date[] = []
+    if (!lastArDate.value || !nextArYear.value) {
+      return reportDates
+    }
+
+    try {
+      const referenceDate = lastArDate.value ? new Date(lastArDate.value) : new Date(foundingDate.value!)
+      const currYear = new Date().getFullYear()
+      const dueMonth = referenceDate.getUTCMonth()
+      const dueDay = referenceDate.getUTCDate()
+
+      // Starts from the next AR year and computes all due dates up to the current year.
+      for (let year = nextArYear.value; year <= currYear; year++) {
+        const reportDueDate = new Date(year, dueMonth, dueDay)
+        reportDates.push(reportDueDate)
+      }
+      return reportDates
+    } catch (e) {
+      return reportDates
     }
   }
 
@@ -158,9 +200,13 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
     loading.value = true
     currentBusiness.value = {} as BusinessFull
     businessNano.value = {} as BusinessNano
-    nextArDate.value = ''
-    payStatus.value = null
     fullDetails.value = {} as Business
+    nanoID.value = null
+    nextArYear.value = null
+    nextArDate.value = null
+    lastArDate.value = null
+    foundingDate.value = null
+    payStatus.value = null
   }
 
   return {
@@ -169,13 +215,18 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
     getBusinessTask,
     assignBusinessStoreValues,
     getFullBusinessDetails,
+    getArDueDates,
     $reset,
     loading,
     currentBusiness,
     businessNano,
     nextArDate,
     payStatus,
-    fullDetails
+    fullDetails,
+    nextArYear,
+    lastArDate,
+    nanoID,
+    foundingDate
   }
 },
 { persist: true } // persist store values in session storage

--- a/web/site/utils/date.ts
+++ b/web/site/utils/date.ts
@@ -30,6 +30,14 @@ export function datetimeStringToDateString (datetimeString: string) {
   return (date) ? moment(date).local().format('YYYY-MM-DD') : ''
 }
 
+/** Return the date string as a date object in local time
+ * @param dateString expected dateString format: YYYY-MM-DDTHH:MM:SS-00:00 or any valid ISO string
+ */
+export function isoDateStringToLocalDate (dateString: string) {
+  const dateMoment = moment(dateString)
+  return dateMoment.isValid() ? dateMoment.local().toDate() : null
+}
+
 export function addOneYear (dateString: string) {
   const date = dateStringToDate(dateString)
   return moment(date).add(1, 'year').format('YYYY-MM-DD')


### PR DESCRIPTION
API:
1. feat: ability to check un-synced filings in GCP
	api/models/filing.py
	   - `get_next_ar_fiscal_year()` created
	   - `get_last_ar_filed_date()` created

3. feat: check GCP for un-synced filings to enable multiple ARs
	api/services/business_service.py
	- `get_business_details_from_colin()` adjusted to check GCP as well as Colin
	- `get_business_pending_tasks()` adjusted to allow for multiple filings

3. feat: bus request via token responds with next AR Year &  last AR date`
	api/resources/business.py
	- `get_business_details_using_token()` responds with info to be able to calculate num ARs

UI:
1. feat: data storage to allow filing multiple ARs
	site/stores/business.ts
	  - Added variables related to AR dates
	  - `getBusinessByNanoId()` adjusted to store AR date related values directly
	  - `getFullBusinessDetails()` adjusted to store AR date related values directly
	  - `getArDueDates()` implemented to get chronological filings to do for the business
	  - `assignBusinessStoreValues()` adjusted to no longer fallback to founding date (occurs already in `getBusinessByNanoId` and `getFullBusinessDetails`)
2. feat: business nano includes info to calculate AR due dates
	site/interfaces/business.ts
	- `BusinessNano` type contains info to calculate all AR due dates
3. feat: ensure proper formatting of AR date when submitting
	site/stores/annual-report.ts
	- `submitAnnualReportFiling()` adjusted to ensure dates are correct when submitting an AR
4. feat: functionality to convert ISO wildcard date to properly formatted local date
	site/utils/date.ts
5. feat: display all due filings when user is selecting a filing
	site/components/Sbc/BusinessInfo.vue
	- Component passed data to display multiple filings
	- Component displays multiple filings and login button when show multiple filings is true
	- Help trigger location moved
6. feat: add component to select file another filing
   site/components/Sbc/FileAnotherReport.vue
     - Component displays after successful completion of AR
     - Component displays filings to do with option to select the next one
7. feat: ui adjustments
	site/components/Sbc/NuxtContentCard.vue
	site/components/Sbc/Help/Trigger.vue
	site/components/content/DocumentDownload.vue
	site/pages/annual-report.vue
8. feat: index page displays all ARs when nano ID entered
	site/pages/index.vue
	- UI adjustments
	- UI displays all filings when nano ID entered with option to select an account on the most recent one
9. feat: submitted page has option to file for next year
   site/pages/submitted.vue
    - UI displays additional filings with option to do the next one in order
    - Functionality to reset AR store in order to start another filing fresh
    
    
**Things that still need to be done**
- Refine UI
- UI for mobile
- French translations
- Bring back middleware on Annual-Report page
- Document Download button needs to be reworked
- Failing tests need to be fixed, possible add some more tests