### PR TITLE
fix: prepend legal-type before identifier in business info

### DIFF
--- a/web/site/pages/annual-report.vue
+++ b/web/site/pages/annual-report.vue
@@ -231,7 +231,7 @@ if (import.meta.client) {
             break-value="lg"
             :items="[
               { label: $t('labels.busName'), value: busStore.currentBusiness.legalName },
-              { label: $t('labels.corpNum'), value: busStore.businessNano.identifier },
+              { label: $t('labels.corpNum'), value: `${busStore.businessNano.legalType}${busStore.businessNano.identifier.replace(/\D/g, '')}`},
               { label: $t('labels.arDate'), value: nextArDate },
             ]"
             :is-selecting-filing="false"

--- a/web/site/pages/index.vue
+++ b/web/site/pages/index.vue
@@ -142,7 +142,7 @@ if (import.meta.client) {
           break-value="sm"
           :items="[
             { label: $t('labels.busName'), value: busStore.businessNano.legalName },
-            { label: $t('labels.corpNum'), value: busStore.businessNano.identifier },
+            { label: $t('labels.corpNum'), value: `${busStore.businessNano.legalType}${busStore.businessNano.identifier.replace(/\D/g, '')}`},
             { label: $t('labels.busNum'), value: busStore.businessNano.taxId ? `${busStore.businessNano.taxId.slice(0, 9)} ${busStore.businessNano.taxId.slice(9)}` : null },
           ]"
           :is-selecting-filing="true"

--- a/web/site/pages/submitted.vue
+++ b/web/site/pages/submitted.vue
@@ -87,7 +87,7 @@ if (import.meta.client) {
         <SbcFileAnotherReport
           :items="[
             { label: $t('labels.busName'), value: busStore.businessNano.legalName },
-            { label: $t('labels.corpNum'), value: busStore.businessNano.identifier },
+            { label: $t('labels.corpNum'), value: `${busStore.businessNano.legalType}${busStore.businessNano.identifier.replace(/\D/g, '')}`},
             { label: $t('labels.busNum'), value: busStore.businessNano.taxId ? `${busStore.businessNano.taxId.slice(0, 9)} ${busStore.businessNano.taxId.slice(9)}` : null },
           ]"
           :last-a-r-completed-year="lastARDate!.getFullYear()"


### PR DESCRIPTION
Made it so legal type (e.g. BC) is prepended before business identifier. Also made sure the identifier does not show the legal type by ensuring it is only numerical. 