### PR TITLE
fix: ensure ar dates always have same month/day as founding

### DIFF
--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "business-ar-ui",
   "private": true,
   "type": "module",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -14,11 +14,16 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         apiSuffix += `/${arFiling.value.filing.header.id}`
       }
 
-      // format the ar date to be sent
-      const arDate = busStore.nextArDate
-        ? (busStore.nextArDate instanceof Date
-            ? busStore.nextArDate.toISOString().slice(0, 10)
-            : new Date(busStore.nextArDate).toISOString().slice(0, 10))
+      // Create the AR date with the same month/day as the founding date
+      const arDate = busStore.nextArDate && busStore.foundingDate
+        ? (() => {
+            const arDueDate = new Date(
+              busStore.nextArDate.getFullYear(),
+              busStore.foundingDate.getMonth(),
+              busStore.foundingDate.getDate()
+            )
+            return arDueDate.toISOString().slice(0, 10)
+          })()
         : null
 
       const response = await useBarApi<ArFiling>(

--- a/web/site/stores/business.ts
+++ b/web/site/stores/business.ts
@@ -30,7 +30,7 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
         nextArYear.value = response.nextARYear || null
 
         if (response.nextARYear) {
-          nextArDate.value = new Date(response.nextARYear, lastArDate.value!.getUTCMonth(), lastArDate.value!.getUTCDate())
+          nextArDate.value = new Date(response.nextARYear, foundingDate.value!.getMonth(), foundingDate.value!.getDate())
         } else {
           nextArDate.value = null
         }
@@ -63,7 +63,7 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
         nextArYear.value = response.business.nextARYear || null
 
         if (nextArYear.value) {
-          nextArDate.value = new Date(nextArYear.value, lastArDate.value!.getMonth(), lastArDate.value!.getDate())
+          nextArDate.value = new Date(nextArYear.value, foundingDate.value!.getMonth(), foundingDate.value!.getDate())
         } else {
           nextArDate.value = null
         }
@@ -125,14 +125,12 @@ export const useBusinessStore = defineStore('bar-sbc-business-store', () => {
     }
 
     try {
-      const referenceDate = lastArDate.value ? new Date(lastArDate.value) : new Date(foundingDate.value!)
+      const referenceDate = new Date(foundingDate.value!)
       const currYear = new Date().getFullYear()
-      const dueMonth = referenceDate.getUTCMonth()
-      const dueDay = referenceDate.getUTCDate()
 
-      // Starts from the next AR year and computes all due dates up to the current year.
+      // Starts from the next AR year and computes all due dates up to the current year
       for (let year = nextArYear.value; year <= currYear; year++) {
-        const reportDueDate = new Date(year, dueMonth, dueDay)
+        const reportDueDate = new Date(year, referenceDate.getMonth(), referenceDate.getDate())
         reportDates.push(reportDueDate)
       }
       return reportDates


### PR DESCRIPTION
This PR ensures that the AR Date always has the same month and day as the founding date of the business. 

It is the AR date that is used to calculate the period_end_date in Lear. 