### PR TITLE
461 - Update `get_last_ar_filed_date` to Include Pending Filing Status

### DIFF
--- a/api/src/business_ar_api/models/filing.py
+++ b/api/src/business_ar_api/models/filing.py
@@ -151,7 +151,7 @@ class Filing(BaseModel):
     def get_last_ar_filed_date(cls, business_id: str) -> str | None:
         """Get the last AR filed date."""
         try:
-            status = [Filing.Status.COMPLETED, Filing.Status.PAID]
+            status = [Filing.Status.COMPLETED, Filing.Status.PAID, Filing.Status.PENDING]
             query = (
                 db.session.query(Filing)
                 .filter(Filing.business_id == int(business_id))


### PR DESCRIPTION
## Description
When multiple Annual Reports (ARs) are filed in quick succession, the second filing might not update the `last_ar_filed_date` correctly. To address this issue, the `get_last_ar_filed_date` method is modified to include filings with the `PENDING` status.

### Changes Made
- Added `Filing.Status.PENDING` to the list of statuses checked in the `get_last_ar_filed_date` method.
