### PR TITLE
473-Fix timezone conversion issue

### DIFF
--- a/jobs/process_paid_filings/src/process_paid_filings/job.py
+++ b/jobs/process_paid_filings/src/process_paid_filings/job.py
@@ -217,11 +217,10 @@ def run():
                 # The Colin API sends the founding date in UTC, but we need to convert it
                 # back to the local Pacific Time zone to ensure the last_ar_filed_date reflects
                 # the same calendar day locally as when the business was founded.
-                utc_founding_date = datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
-                if utc_founding_date.time() == datetime.min.time():
-                    utc_founding_date = utc_founding_date.replace(hour=12, tzinfo=pytz.utc)
-                else:
-                    utc_founding_date = utc_founding_date.replace(tzinfo=pytz.utc)
+                utc_founding_date = (
+                    datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
+                    .replace(tzinfo=pytz.utc)
+                )
                 pacific_founding_date = utc_founding_date.astimezone(pytz.timezone('America/Los_Angeles'))
                 filing["filing"]["business"]["foundingDate"] = pacific_founding_date.isoformat()
 

--- a/jobs/process_paid_filings/src/process_paid_filings/job.py
+++ b/jobs/process_paid_filings/src/process_paid_filings/job.py
@@ -217,10 +217,11 @@ def run():
                 # The Colin API sends the founding date in UTC, but we need to convert it
                 # back to the local Pacific Time zone to ensure the last_ar_filed_date reflects
                 # the same calendar day locally as when the business was founded.
-                utc_founding_date = (
-                    datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
-                    .replace(tzinfo=pytz.utc)
-                )
+                utc_founding_date = datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
+                if utc_founding_date.time() == datetime.min.time():
+                    utc_founding_date = utc_founding_date.replace(hour=12, tzinfo=pytz.utc)
+                else:
+                    utc_founding_date = utc_founding_date.replace(tzinfo=pytz.utc)
                 pacific_founding_date = utc_founding_date.astimezone(pytz.timezone('America/Los_Angeles'))
                 filing["filing"]["business"]["foundingDate"] = pacific_founding_date.isoformat()
 

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -20,7 +20,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
       // Create the AR date with the same month/day as the founding date
       const arDate = busStore.nextArDate && busStore.foundingDate
         ? (() => {
-            const arDueDate = new Date(Date.UTC(
+            const arDueDate = new Date((
               busStore.nextArDate.getFullYear(),
               busStore.foundingDate.getMonth(),
               busStore.foundingDate.getDate()


### PR DESCRIPTION
issue: #473 
# Fix timezone conversion issue for foundingDate to prevent date mismatches

## Description

This PR addresses the issue where the `foundingDate` conversion from UTC to Pacific Time could result in an off-by-one-day error, leading to mismatches between `period_end_dt` and `last_ar_filed_dt`. The following changes have been made:

- Adjusted the conversion of `foundingDate` from UTC to Pacific Time to handle date-only values correctly.
- Set the time to noon UTC if the `foundingDate` lacks time information to prevent date shifts.
- Ensured consistent handling of `foundingDate` as a date without unnecessary timezone conversions.

## Changes

- Modified `job.py` to handle `foundingDate` conversion correctly:
  ```python
  # Convert the founding date from UTC to Pacific Time.
  utc_founding_date = datetime.fromisoformat(filing["filing"]["business"]["foundingDate"])
  if utc_founding_date.time() == datetime.min.time():
      utc_founding_date = utc_founding_date.replace(hour=12, tzinfo=pytz.utc)
  else:
      utc_founding_date = utc_founding_date.replace(tzinfo=pytz.utc)
  pacific_founding_date = utc_founding_date.astimezone(pytz.timezone('America/Los_Angeles'))
  filing["filing"]["business"]["foundingDate"] = pacific_founding_date.isoformat()