### PR TITLE
471-Fix Annual Report Date Timezone Inconsistencies

### DIFF
--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -8,6 +8,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
 
   async function submitAnnualReportFiling (arData: ArFormData): Promise<{ paymentToken: number, filingId: number, payStatus: string }> {
     try {
+      const startTime = performance.now()
       let apiSuffix = `/business/${busStore.businessNano.identifier}/filings`
       // add filing id to end of url if filing exists in the store
       if (Object.keys(arFiling.value).length !== 0) {
@@ -58,6 +59,9 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
       const filingId = response.filing.header.id
       const payStatus = response.filing.header.status
 
+      const endTime = performance.now()
+      console.log(`submitAnnualReportFiling took ${endTime - startTime} milliseconds`)
+      
       return { paymentToken, filingId, payStatus }
     } catch (e) {
       alertStore.addAlert({

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -23,8 +23,8 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         ? (() => {
             const arDueDate = new Date(
               busStore.nextArDate.getFullYear(),
-              busStore.foundingDate.getMonth(),
-              busStore.foundingDate.getDate()
+              busStore.foundingDate.getUTCMonth(),
+              busStore.foundingDate.getUTCDate()
             )
             return arDueDate.toISOString().slice(0, 10)
           })()
@@ -61,7 +61,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
 
       const endTime = performance.now()
       console.log(`submitAnnualReportFiling took ${endTime - startTime} milliseconds`)
-      
+
       return { paymentToken, filingId, payStatus }
     } catch (e) {
       alertStore.addAlert({


### PR DESCRIPTION
issue: #473 

### Description
When calculating annual report dates, timezone differences could cause the AR date to be off by one day from the founding date.

### Changes
- Modified AR date calculation to use consistent UTC handling
- Uses `getUTCDate` to ensure timezone-independent date creation