### PR TITLE
471 add logs for queue services

### DIFF
--- a/jobs/process_paid_filings/src/process_paid_filings/job.py
+++ b/jobs/process_paid_filings/src/process_paid_filings/job.py
@@ -198,6 +198,10 @@ def run():
             token = AccountService.get_service_client_token(client_id, client_secret)
             filings_res = get_filings(app=application, token=token)
             filings = filings_res.get("filings")
+            if filings:
+                filings.sort(key=lambda x: x["filing"]["header"]["id"])
+            else:
+                application.logger.debug("No completed filings to send to colin.")
             if not filings:
                 # pylint: disable=no-member; false positive
                 application.logger.debug("No completed filings to send to colin.")

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -8,6 +8,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
 
   async function submitAnnualReportFiling (arData: ArFormData): Promise<{ paymentToken: number, filingId: number, payStatus: string }> {
     try {
+      const startTime = performance.now()
       let apiSuffix = `/business/${busStore.businessNano.identifier}/filings`
       // add filing id to end of url if filing exists in the store
       if (Object.keys(arFiling.value).length !== 0) {
@@ -58,6 +59,9 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
       const filingId = response.filing.header.id
       const payStatus = response.filing.header.status
 
+      const endTime = performance.now()
+      console.log(`submitAnnualReportFiling took ${endTime - startTime} milliseconds`)
+      
       return { paymentToken, filingId, payStatus }
     } catch (e) {
       alertStore.addAlert({

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -23,8 +23,8 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         ? (() => {
             const arDueDate = new Date(
               busStore.nextArDate.getFullYear(),
-              busStore.foundingDate.getMonth(),
-              busStore.foundingDate.getDate()
+              busStore.foundingDate.getUTCMonth(),
+              busStore.foundingDate.getUTCDate()
             )
             return arDueDate.toISOString().slice(0, 10)
           })()
@@ -61,7 +61,7 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
 
       const endTime = performance.now()
       console.log(`submitAnnualReportFiling took ${endTime - startTime} milliseconds`)
-      
+
       return { paymentToken, filingId, payStatus }
     } catch (e) {
       alertStore.addAlert({

--- a/web/site/stores/annual-report.ts
+++ b/web/site/stores/annual-report.ts
@@ -23,8 +23,8 @@ export const useAnnualReportStore = defineStore('bar-sbc-annual-report-store', (
         ? (() => {
             const arDueDate = new Date(
               busStore.nextArDate.getFullYear(),
-              busStore.foundingDate.getUTCMonth(),
-              busStore.foundingDate.getUTCDate()
+              busStore.foundingDate.getMonth(),
+              busStore.foundingDate.getDate()
             )
             return arDueDate.toISOString().slice(0, 10)
           })()


### PR DESCRIPTION
# Description
issue: #461 
This PR addresses an issue where Annual Report filings could be processed out of chronological order when multiple filings are submitted in quick succession. This caused scenarios where newer filings (e.g. 2024) were being processed before older ones (e.g. 2023).

## Changes
1. Added sorting by filing ID in the process_paid_filings job to ensure chronological processing
2. Added performance monitoring for AR submission API calls
3. Added logging for better tracking of filing processing order

## Files Changed
- jobs/process_paid_filings/src/process_paid_filings/job.py
- web/site/stores/annual-report.ts
