### PR TITLE
Reduced Workflow Names Length for CICD Pipelines

### DIFF
--- a/.github/workflows/business-ar-business-sync-cd.yaml
+++ b/.github/workflows/business-ar-business-sync-cd.yaml
@@ -19,11 +19,11 @@ on:
         - prod
 
 jobs:
-  business-ar-job-business-sync-cd:
+  bar-business-sync-cd:
     uses: bcgov/bcregistry-sre/.github/workflows/backend-job-cd.yaml@main
     with:
       target: ${{ inputs.target }}
-      app_name: "business-ar-job-business-sync"
+      app_name: "bar-business-sync"
       working_directory: "./jobs/business-sync"
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}

--- a/.github/workflows/business-ar-business-sync-ci.yaml
+++ b/.github/workflows/business-ar-business-sync-ci.yaml
@@ -12,10 +12,10 @@ defaults:
     working-directory: ./jobs/business-sync
 
 jobs:
-  business-ar-job-business-sync-ci:
+  bar-business-sync-ci:
     uses: bcgov/bcregistry-sre/.github/workflows/backend-ci.yaml@main
     with:
-      app_name: "business-ar-job-business-sync"
+      app_name: "bar-business-sync"
       working_directory: "./jobs/business-sync"
       codecov_flag: "businessarbusiness_sync"
       skip_isort: "true"

--- a/.github/workflows/business-ar-process-paid-filings-cd.yaml
+++ b/.github/workflows/business-ar-process-paid-filings-cd.yaml
@@ -19,11 +19,11 @@ on:
         - prod
 
 jobs:
-  business-ar-job-process-paid-filings-cd:
+  bar-paid-filings-job-cd:
     uses: bcgov/bcregistry-sre/.github/workflows/backend-job-cd.yaml@main
     with:
       target: ${{ inputs.target }}
-      app_name: "business-ar-job-process-paid-filings"
+      app_name: "bar-paid-filings-job"
       working_directory: "./jobs/process_paid_filings"
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}

--- a/.github/workflows/business-ar-process-paid-filings-ci.yaml
+++ b/.github/workflows/business-ar-process-paid-filings-ci.yaml
@@ -12,10 +12,10 @@ defaults:
     working-directory: ./jobs/process_paid_filings
 
 jobs:
-  business-ar-job-process-paid-filings-cd:
+  bar-paid-filings-job-ci:
     uses: bcgov/bcregistry-sre/.github/workflows/backend-ci.yaml@main
     with:
-      app_name: "business-ar-job-process-paid-filings"
+      app_name: "bar-paid-filings-job"
       working_directory: "./jobs/process_paid_filings"
       codecov_flag: "businessarprocess_paid_filings"
       skip_isort: "true"

--- a/jobs/business-sync/devops/gcp/clouddeploy.yaml
+++ b/jobs/business-sync/devops/gcp/clouddeploy.yaml
@@ -29,7 +29,7 @@
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
 metadata:
- name: business-business-sync-pipeline
+ name: bar-business-sync-pipeline
 description: Deployment pipeline
 serialPipeline:
  stages:
@@ -42,7 +42,7 @@ serialPipeline:
    - values:
       deploy-env: "development"
       deploy-project-id: "a083gt-dev"
-      job-name: "business-ar-business-sync-dev"
+      job-name: "bar-business-sync-dev"
       cloudsql-instances: "a083gt-dev:northamerica-northeast1:businesses-db-dev"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-dev.iam.gserviceaccount.com"
@@ -55,7 +55,7 @@ serialPipeline:
    - values:
       deploy-env: "development"
       deploy-project-id: "a083gt-test"
-      job-name: "business-ar-business-sync-test"
+      job-name: "bar-business-sync-test"
       cloudsql-instances: "a083gt-test:northamerica-northeast1:businesses-db-test"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-test.iam.gserviceaccount.com"
@@ -68,7 +68,7 @@ serialPipeline:
    - values:
       deploy-env: "production"
       deploy-project-id: "a083gt-integration"
-      job-name: "business-ar-business-sync-sandbox"
+      job-name: "bar-business-sync-sandbox"
       cloudsql-instances: "a083gt-integration:northamerica-northeast1:businesses-db-sandbox"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-integration.iam.gserviceaccount.com"
@@ -81,7 +81,7 @@ serialPipeline:
    - values:
       deploy-env: "production"
       deploy-project-id: "a083gt-prod"
-      job-name: "business-ar-business-sync-prod"
+      job-name: "bar-business-sync-prod"
       cloudsql-instances: "a083gt-prod:northamerica-northeast1:businesses-db-prod"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-prod.iam.gserviceaccount.com"

--- a/jobs/process_paid_filings/devops/gcp/clouddeploy.yaml
+++ b/jobs/process_paid_filings/devops/gcp/clouddeploy.yaml
@@ -29,7 +29,7 @@
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
 metadata:
- name: business-ar-process-paid-filings-pipeline
+ name: bar-paid-filings-job-pipeline
 description: Deployment pipeline
 serialPipeline:
  stages:
@@ -42,7 +42,7 @@ serialPipeline:
    - values:
       deploy-env: "development"
       deploy-project-id: "a083gt-dev"
-      job-name: "business-ar-job-process-paid-filings-dev"
+      job-name: "bar-paid-filings-job-dev"
       cloudsql-instances: "a083gt-dev:northamerica-northeast1:businesses-db-dev"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-dev.iam.gserviceaccount.com"
@@ -55,7 +55,7 @@ serialPipeline:
    - values:
       deploy-env: "development"
       deploy-project-id: "a083gt-test"
-      job-name: "business-ar-job-process-paid-filings-test"
+      job-name: "bar-paid-filings-job-test"
       cloudsql-instances: "a083gt-test:northamerica-northeast1:businesses-db-test"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-test.iam.gserviceaccount.com"
@@ -68,7 +68,7 @@ serialPipeline:
    - values:
       deploy-env: "sandbox"
       deploy-project-id: "a083gt-integration"
-      job-name: "business-ar-job-process-paid-filings-sandbox"
+      job-name: "bar-paid-filings-job-sandbox"
       cloudsql-instances: "a083gt-integration:northamerica-northeast1:businesses-db-sandbox"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-integration.iam.gserviceaccount.com"
@@ -81,7 +81,7 @@ serialPipeline:
    - values:
       deploy-env: "production"
       deploy-project-id: "a083gt-prod"
-      job-name: "business-ar-job-process-paid-filings-prod"
+      job-name: "bar-paid-filings-job-prod"
       cloudsql-instances: "a083gt-prod:northamerica-northeast1:businesses-db-prod"
       run-command: "./run.sh"
       service-account: "sa-job@a083gt-prod.iam.gserviceaccount.com"


### PR DESCRIPTION
#### **Description**
1. This PR simplifies and shortens workflow names to align with Google Cloud's resource ID constraints.
---

#### **Changes**

1. **Workflows Updated:**
   - **`business-ar-business-sync-cd.yaml`**:
     - Renamed `business-ar-job-business-sync-cd` to `bar-business-sync-cd`.
     - Updated `app_name` from `business-ar-job-business-sync` to `bar-business-sync`.
   - **`business-ar-business-sync-ci.yaml`**:
     - Renamed `business-ar-job-business-sync-ci` to `bar-business-sync-ci`.
     - Updated `app_name` from `business-ar-job-business-sync` to `bar-business-sync`.
   - **`business-ar-process-paid-filings-cd.yaml`**:
     - Renamed `business-ar-job-process-paid-filings-cd` to `bar-paid-filings-job-cd`.
     - Updated `app_name` from `business-ar-job-process-paid-filings` to `bar-paid-filings-job`.
   - **`business-ar-process-paid-filings-ci.yaml`**:
     - Renamed `business-ar-job-process-paid-filings-ci` to `bar-paid-filings-job-ci`.
     - Updated `app_name` from `business-ar-job-process-paid-filings` to `bar-paid-filings-job`.

2. **Delivery Pipeline Updates:**
   - Shortened names in `clouddeploy.yaml` for both `business-sync` and `process-paid-filings` jobs:
     - Example: 
       - `business-ar-job-process-paid-filings-dev` → `bar-paid-filings-job-dev`.
       - `business-ar-job-business-sync-prod` → `bar-business-sync-prod`.