### PR TITLE
524-updated locale message

### DIFF
--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -348,14 +348,14 @@ export default {
     methodLabels: {
       DIRECT_PAY: 'Credit Card',
       PAD: 'Pre-authorized Debit (PAD) {account}',
-      BCOL: 'Online Banking',
-      JV: 'Journal Voucher'
+      DRAWDOWN: 'Online Banking',
+      EJV: 'Journal Voucher'
     }
   },
   paymentMethod: {
     DIRECT_PAY: 'Credit Card',
     PAD: 'Pre-authorized Debit (PAD) {account}',
-    BCOL: 'Online Banking',
-    JV: 'Journal Voucher'
+    DRAWDOWN: 'Online Banking',
+    EJV: 'Journal Voucher'
   }
 }

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -346,14 +346,14 @@ export default {
     methodLabels: {
       DIRECT_PAY: 'Carte de crédit',
       PAD: 'Débit préautorisé (PAD) {account}',
-      BCOL: 'Services bancaires en ligne',
-      JV: 'Bon de journal'
+      DRAWDOWN: 'Services bancaires en ligne',
+      EJV: 'Bon de journal'
     }
   },
   paymentMethod: {
     DIRECT_PAY: 'Carte de crédit',
     PAD: 'Débit préautorisé (PAD) {account}',
-    BCOL: 'Services bancaires en ligne',
-    JV: 'Bon de journal'
+    DRAWDOWN: 'Services bancaires en ligne',
+    EJV: 'Bon de journal'
   }
 }


### PR DESCRIPTION
Issue: #524 
## Description

This pull request updates the payment method labels in the `en-CA.ts` and `fr-CA.ts` locale file to reflect the correct terminology. Specifically, it replaces the `BCOL` and `JV` labels with `DRAWDOWN` and `EJV`, respectively.

## Changes

- **Modified Payment Method Labels:**
  - Changed `BCOL` to `DRAWDOWN` for "Online Banking".
  - Changed `JV` to `EJV` for "Journal Voucher".
