### PR TITLE
526-Localize PAD Confirmation Alert

### DIFF
--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -63,6 +63,10 @@ export default {
     'fee-info': {
       title: 'Fee Error',
       description: 'Error retrieving fees, please try again or come back later.'
+    },
+    'pad-confirmation': {
+      title: 'PAD Confirmation',
+      description: 'PAD Account: {accountNumber} is in confirmation period. Please use Credit Card.'
     }
   },
   btn: {

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -63,7 +63,10 @@ export default {
     'fee-info': {
       title: 'Erreur de Frais',
       description: 'Erreur lors de la récupération des frais, veuillez réessayer ou revenir plus tard.'
-    }
+    },
+    'pad-confirmation': {
+      title: 'Débit Préautorisé (PAD) en Période de Confirmation',
+      description: 'Votre compte PAD: {accountNumber} est en période de confirmation. Veuillez utiliser une carte de crédit.'
   },
   btn: {
     getStarted: 'Commencer',

--- a/web/site/stores/pay-fees.ts
+++ b/web/site/stores/pay-fees.ts
@@ -103,7 +103,7 @@ export const usePayFeesStore = defineStore('bar-sbc-pay-fees', () => {
       userSelectedPaymentMethod.value = ConnectPaymentMethod.DIRECT_PAY
       // show alert for user using window.alert instead of a modal
       window.alert(
-        t('PAD Account: ' + userPaymentAccount.value?.cfsAccount?.bankAccountNumber + ' is in confirmation period. Please use Credit Card.') 
+        t('alerts.pad-confirmation.description', { accountNumber: userPaymentAccount.value?.cfsAccount?.bankAccountNumber })
       )
     }
   })

--- a/web/site/stores/pay-fees.ts
+++ b/web/site/stores/pay-fees.ts
@@ -13,6 +13,7 @@ export const usePayFeesStore = defineStore('bar-sbc-pay-fees', () => {
   const userSelectedPaymentMethod = ref<ConnectPaymentMethod>(ConnectPaymentMethod.DIRECT_PAY)
   const allowAlternatePaymentMethod = ref<boolean>(false)
   const allowedPaymentMethods = ref<{ label: string, value: ConnectPaymentMethod }[]>([])
+  const { t } = useI18n()
 
   function addFee (newFee: FeeInfo) {
     const fee = fees.value.find((fee: PayFeesWidgetItem) => // check if fee already exists
@@ -95,6 +96,18 @@ export const usePayFeesStore = defineStore('bar-sbc-pay-fees', () => {
       })
     }
   }
+
+  watch(userSelectedPaymentMethod, () => {
+    // if pad in confirmation period then set selected payment to DIRECT_PAY
+    if (PAD_PENDING_STATES.includes(userPaymentAccount.value?.cfsAccount?.status)) {
+      userSelectedPaymentMethod.value = ConnectPaymentMethod.DIRECT_PAY
+      // show alert for user using window.alert instead of a modal
+      window.alert(
+        t('modal.padConfirmationPeriod.title') + '\n' +
+        t('modal.padConfirmationPeriod.content')
+      )
+    }
+  })
 
   const $resetAlternatePayOptions = () => {
     userPaymentAccount.value = {} as ConnectPayAccount


### PR DESCRIPTION
Issue: #526 
## Summary
- **Update locale files**:  
  Added the `padConfirmationPeriod` key to both `en-CA.ts` and `fr-CA.ts` with proper messages.

- **Update fee payment store**:  
  Modified `pay-fees.ts` to use the localized message with `t('padConfirmationPeriod.content', { bankNumber: ... })` instead of the hard-coded alert message.