### PR TITLE
538 receipt generation

### DIFF
--- a/web/site/components/content/DocumentDownload.vue
+++ b/web/site/components/content/DocumentDownload.vue
@@ -2,6 +2,7 @@
 // handle document download buttons for final page, this will only work for the 2 current file from the backend
 // any updates to the backend this will need to be reworked
 const arStore = useAnnualReportStore()
+const { t } = useI18n()
 </script>
 <template>
   <ClientOnly>
@@ -9,17 +10,21 @@ const arStore = useAnnualReportStore()
       v-if="arStore.arFiling.filing?.documents && arStore.arFiling.filing.documents.length > 0"
       class="flex w-full"
     >
-      <UButton
+      <UTooltip
         v-for="doc in arStore.arFiling.filing.documents"
         :key="doc.name"
-        size="lg"
-        color="blue"
-        variant="outline"
-        icon="i-mdi-tray-arrow-down"
-        :loading="arStore.loading"
-        :label="doc.name === 'Receipt' ? $t('btn.downloadReceipt') : $t('btn.downloadReport')"
-        @click="arStore.handleDocumentDownload(doc)"
-      />
+        :text="t('page.submitted.docEmailNotice')"
+      >
+        <UButton
+          size="lg"
+          color="blue"
+          variant="outline"
+          icon="i-mdi-tray-arrow-down"
+          :loading="arStore.loading"
+          :label="doc.name === 'Receipt' ? $t('btn.downloadReceipt') : $t('btn.downloadReport')"
+          @click="arStore.handleDocumentDownload(doc)"
+        />
+      </UTooltip>
     </div>
   </ClientOnly>
 </template>

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -290,7 +290,8 @@ export default {
     },
     submitted: {
       title: 'Annual Report Complete - Service BC Annual Report',
-      h1: '{year} Annual Report Complete'
+      h1: '{year} Annual Report Complete',
+      docEmailNotice: 'A copy of this document will also be emailed once payment processing is complete.'
     },
     tos: {
       title: 'Terms of Use - Service BC Annual Report',

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -287,8 +287,9 @@ export default {
       noDirectors: 'Aucun réalisateur trouvé'
     },
     submitted: {
-      title: 'Rapport Annuel Terminé - Rapport Annuel de Service CB',
-      h1: 'Rapport Annuel {year} Complété'
+      title: 'Rapport annuel complété - Rapport annuel de Service BC',
+      h1: 'Rapport annuel {year} complété',
+      docEmailNotice: 'Une copie de ce document sera également envoyée par courriel une fois le traitement du paiement terminé.'
     },
     tos: { // TODO: review tos page translations
       title: "Conditions d'Utilisation - Rapport Annuel de Service CB",

--- a/web/site/stores/pay-fees.ts
+++ b/web/site/stores/pay-fees.ts
@@ -13,6 +13,7 @@ export const usePayFeesStore = defineStore('bar-sbc-pay-fees', () => {
   const userSelectedPaymentMethod = ref<ConnectPaymentMethod>(ConnectPaymentMethod.DIRECT_PAY)
   const allowAlternatePaymentMethod = ref<boolean>(false)
   const allowedPaymentMethods = ref<{ label: string, value: ConnectPaymentMethod }[]>([])
+  const { t } = useI18n()
 
   function addFee (newFee: FeeInfo) {
     const fee = fees.value.find((fee: PayFeesWidgetItem) => // check if fee already exists
@@ -95,6 +96,18 @@ export const usePayFeesStore = defineStore('bar-sbc-pay-fees', () => {
       })
     }
   }
+
+  watch(userSelectedPaymentMethod, () => {
+    // if pad in confirmation period then set selected payment to DIRECT_PAY
+    if (PAD_PENDING_STATES.includes(userPaymentAccount.value?.cfsAccount?.status)) {
+      userSelectedPaymentMethod.value = ConnectPaymentMethod.DIRECT_PAY
+      // show alert for user using window.alert instead of a modal
+      window.alert(
+        t('modal.padConfirmationPeriod.title') + '\n' +
+        t('modal.padConfirmationPeriod.content')
+      )
+    }
+  })
 
   const $resetAlternatePayOptions = () => {
     userPaymentAccount.value = {} as ConnectPayAccount


### PR DESCRIPTION
issue: #538 
**Description:**
- Adds tooltips to document download buttons on submission confirmation page
- Informs users that documents will be emailed after payment processing
- Includes English and French translations for tooltip text
