### PR TITLE
28439-updated tooltip for download button

### DIFF
--- a/web/site/components/content/DocumentDownload.vue
+++ b/web/site/components/content/DocumentDownload.vue
@@ -13,7 +13,7 @@ const { t } = useI18n()
       <UTooltip
         v-for="doc in arStore.arFiling.filing.documents"
         :key="doc.name"
-        :text="t('page.submitted.docEmailNotice')"
+        :text="doc.name === 'Receipt' ? t('page.submitted.receiptEmailNotice') : t('page.submitted.docEmailNotice')"
       >
         <UButton
           size="lg"

--- a/web/site/locales/en-CA.ts
+++ b/web/site/locales/en-CA.ts
@@ -295,7 +295,8 @@ export default {
     submitted: {
       title: 'Annual Report Complete - Service BC Annual Report',
       h1: '{year} Annual Report Complete',
-      docEmailNotice: 'A copy of this document will also be emailed once payment processing is complete.'
+      docEmailNotice: 'A copy of this document will also be emailed once payment processing is complete.',
+      receiptEmailNotice: 'Annual Report will be emailed once payment processing is complete.'
     },
     tos: {
       title: 'Terms of Use - Service BC Annual Report',

--- a/web/site/locales/fr-CA.ts
+++ b/web/site/locales/fr-CA.ts
@@ -293,7 +293,8 @@ export default {
     submitted: {
       title: 'Rapport annuel complété - Rapport annuel de Service BC',
       h1: 'Rapport annuel {year} complété',
-      docEmailNotice: 'Une copie de ce document sera également envoyée par courriel une fois le traitement du paiement terminé.'
+      docEmailNotice: 'Une copie de ce document sera également envoyée par courriel une fois le traitement du paiement terminé.',
+      receiptEmailNotice: 'Le rapport annuel sera envoyé par courriel une fois le traitement du paiement terminé.'
     },
     tos: { // TODO: review tos page translations
       title: "Conditions d'Utilisation - Rapport Annuel de Service CB",


### PR DESCRIPTION
issue: 
#[28439](https://github.com/bcgov/entity/issues/28439)
### Description
This PR updates the email notice text specifically for Receipt documents to provide clearer messaging about when the Annual Report will be sent.

### Changes
- **Modified conditional text rendering** in `DocumentDownload.vue` to show different notice text for Receipt documents vs other documents
- **Added new localization string** `receiptEmailNotice` in both English and French translations

### Details
- For Receipt documents: Users will now see "Annual Report will be emailed once payment processing is complete"
- For other documents: The existing message "A copy of this document will also be emailed once payment processing is complete" remains unchanged
- French translation included: "Le rapport annuel sera envoyé par courriel une fois le traitement du paiement terminé"

### Files Changed
- `web/site/components/content/DocumentDownload.vue` (1 line modified)
- `web/site/locales/en-CA.ts` (1 line added)
- `web/site/locales/fr-CA.ts` (1 line added)